### PR TITLE
Fixed SurfacePlane functionality in Editor

### DIFF
--- a/Assets/HoloToolkit/SpatialMapping/Scripts/PlaneFinding.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/PlaneFinding.cs
@@ -22,6 +22,18 @@ namespace HoloToolkit.Unity
         public Plane Plane;
         public OrientedBoundingBox Bounds;
         public float Area;
+
+        public BoundedPlane(Transform xform)
+        {
+            Plane = new Plane(xform.forward, xform.position);
+            Bounds = new OrientedBoundingBox()
+            {
+                Center = xform.position,
+                Extents = xform.localScale / 2,
+                Rotation = xform.rotation
+            };
+            Area = Bounds.Extents.x * Bounds.Extents.y;
+        }
     };
 
     public class PlaneFinding

--- a/Assets/HoloToolkit/SpatialMapping/Scripts/PlaneFinding.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/PlaneFinding.cs
@@ -23,6 +23,9 @@ namespace HoloToolkit.Unity
         public OrientedBoundingBox Bounds;
         public float Area;
 
+        /// <summary>
+        /// Builds the bounded plane to match the obb defined by xform
+        /// </summary>
         public BoundedPlane(Transform xform)
         {
             Plane = new Plane(xform.forward, xform.position);

--- a/Assets/HoloToolkit/SpatialMapping/Scripts/SurfacePlane.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/SurfacePlane.cs
@@ -104,6 +104,16 @@ namespace HoloToolkit.Unity
             }
         }
 
+        private void Awake()
+        {
+            plane = new BoundedPlane(transform);
+        }
+
+        private void Start()
+        {
+            UpdateSurfacePlane();
+        }
+
         /// <summary>
         /// Updates the SurfacePlane object to have the same configuration of the BoundingPlane object.
         /// Determine what type of plane the SurfacePlane aligns to.


### PR DESCRIPTION
Added method BoundedPlane to build from Transform.
In SurfacePlane Awake, set plane to BoundedPlane from self transform.
In SurfacePlane Start, update the surface plane.

Note that UpdateToSurface is delayed until start so that SurfaceMeshesToPlanes.Instance can be initialized by the it's Awake call. Setting the plane must happen in Awake so that modifications when instantiated dynamically aren't overwritten.