### PR TITLE
GazeStabilizer Optimization

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/GazeStabilizer.cs
+++ b/Assets/HoloToolkit/Input/Scripts/GazeStabilizer.cs
@@ -49,7 +49,7 @@ namespace HoloToolkit.Unity
             public float timestamp;
         };
 
-        private List<GazeSample> stabilitySamples = new List<GazeSample>();
+        private LinkedList<GazeSample> stabilitySamples = new LinkedList<GazeSample>();
 
         private Vector3 gazePosition;
         private Vector3 gazeDirection;
@@ -102,13 +102,13 @@ namespace HoloToolkit.Unity
 
             if (stabilitySamples != null)
             {
-                // Remove from front if we exceed stored samples.
-                if (stabilitySamples.Count >= StoredStabilitySamples)
+                // Remove from front items if we exceed stored samples.
+                while (stabilitySamples.Count >= StoredStabilitySamples)
                 {
-                    stabilitySamples.RemoveAt(0);
+                    stabilitySamples.RemoveFirst();
                 }
 
-                stabilitySamples.Add(newStabilitySample);
+                stabilitySamples.AddLast(newStabilitySample);
             }
         }
 
@@ -136,13 +136,10 @@ namespace HoloToolkit.Unity
                 return;
             }
 
-            mostRecentSample = stabilitySamples[(stabilitySamples.Count - 1)];
+            mostRecentSample = stabilitySamples.Last.Value;
 
-            // All but most recent.
-            for (int i = 0; i < stabilitySamples.Count - 1; ++i)
-            {
-                GazeSample sample = stabilitySamples[i];
-
+            foreach(GazeSample sample in stabilitySamples)
+            {    
                 // Calculate difference between current sample and most recent sample.
                 positionDelta = Vector3.Magnitude(sample.position - mostRecentSample.position);
 

--- a/Assets/HoloToolkit/Input/Scripts/GazeStabilizer.cs
+++ b/Assets/HoloToolkit/Input/Scripts/GazeStabilizer.cs
@@ -49,7 +49,7 @@ namespace HoloToolkit.Unity
             public float timestamp;
         };
 
-        private Queue<GazeSample> stabilitySamples = new Queue<GazeSample>();
+        private List<GazeSample> stabilitySamples = new List<GazeSample>();
 
         private Vector3 gazePosition;
         private Vector3 gazeDirection;
@@ -68,10 +68,10 @@ namespace HoloToolkit.Unity
 
         /// <summary>
         /// Updates the StableHeadPosition and StableHeadRotation based on GazeSample values.
-        /// Call this method with RaycastHit parameters to get stable values.
+        /// Call this method with Raycasthit parameters to get stable values.
         /// </summary>
-        /// <param name="position">Position value from a RaycastHit point.</param>
-        /// <param name="rotation">Rotation value from a RaycastHit rotation.</param>
+        /// <param name="position">Position value from a Raycasthit point.</param>
+        /// <param name="rotation">Roration value from a Raycasthit rotation.</param>
         public void UpdateHeadStability(Vector3 position, Quaternion rotation)
         {
             gazePosition = position;
@@ -105,10 +105,10 @@ namespace HoloToolkit.Unity
                 // Remove from front if we exceed stored samples.
                 if (stabilitySamples.Count >= StoredStabilitySamples)
                 {
-                    stabilitySamples.Dequeue();
+                    stabilitySamples.RemoveAt(0);
                 }
 
-                stabilitySamples.Enqueue(newStabilitySample);
+                stabilitySamples.Add(newStabilitySample);
             }
         }
 
@@ -136,15 +136,17 @@ namespace HoloToolkit.Unity
                 return;
             }
 
-            mostRecentSample = stabilitySamples.ElementAt(stabilitySamples.Count - 1);
+            mostRecentSample = stabilitySamples[(stabilitySamples.Count - 1)];
 
             // All but most recent.
             for (int i = 0; i < stabilitySamples.Count - 1; ++i)
             {
-                // Calculate difference between current sample and most recent sample.
-                positionDelta = Vector3.Magnitude(stabilitySamples.ElementAt(i).position - mostRecentSample.position);
+                GazeSample sample = stabilitySamples[i];
 
-                directionDelta = Vector3.Angle(stabilitySamples.ElementAt(i).direction, mostRecentSample.direction) * Mathf.Deg2Rad;
+                // Calculate difference between current sample and most recent sample.
+                positionDelta = Vector3.Magnitude(sample.position - mostRecentSample.position);
+
+                directionDelta = Vector3.Angle(sample.direction, mostRecentSample.direction) * Mathf.Deg2Rad;
 
                 // Initialize max and min on first sample.
                 if (i == 0)

--- a/Assets/HoloToolkit/Input/Scripts/GazeStabilizer.cs
+++ b/Assets/HoloToolkit/Input/Scripts/GazeStabilizer.cs
@@ -138,6 +138,7 @@ namespace HoloToolkit.Unity
 
             mostRecentSample = stabilitySamples.Last.Value;
 
+            int i = 0;
             foreach(GazeSample sample in stabilitySamples)
             {    
                 // Calculate difference between current sample and most recent sample.
@@ -146,7 +147,7 @@ namespace HoloToolkit.Unity
                 directionDelta = Vector3.Angle(sample.direction, mostRecentSample.direction) * Mathf.Deg2Rad;
 
                 // Initialize max and min on first sample.
-                if (i == 0)
+                if (i==0)
                 {
                     positionDeltaMin = positionDelta;
                     positionDeltaMax = positionDelta;
@@ -165,6 +166,8 @@ namespace HoloToolkit.Unity
 
                 positionDeltaMean += positionDelta;
                 directionDeltaMean += directionDelta;
+
+                i++;
             }
 
             positionDeltaMean = positionDeltaMean / (stabilitySamples.Count - 1);

--- a/Assets/HoloToolkit/Input/Scripts/GazeStabilizer.cs
+++ b/Assets/HoloToolkit/Input/Scripts/GazeStabilizer.cs
@@ -70,8 +70,8 @@ namespace HoloToolkit.Unity
         /// Updates the StableHeadPosition and StableHeadRotation based on GazeSample values.
         /// Call this method with Raycasthit parameters to get stable values.
         /// </summary>
-        /// <param name="position">Position value from a Raycasthit point.</param>
-        /// <param name="rotation">Roration value from a Raycasthit rotation.</param>
+        /// <param name="position">Position value from a RaycastHit point.</param>
+        /// <param name="rotation">Rotation value from a RaycastHit rotation.</param>
         public void UpdateHeadStability(Vector3 position, Quaternion rotation)
         {
             gazePosition = position;
@@ -138,7 +138,7 @@ namespace HoloToolkit.Unity
 
             mostRecentSample = stabilitySamples.Last.Value;
 
-            int i = 0;
+            bool first = true;
             foreach(GazeSample sample in stabilitySamples)
             {    
                 // Calculate difference between current sample and most recent sample.
@@ -147,12 +147,13 @@ namespace HoloToolkit.Unity
                 directionDelta = Vector3.Angle(sample.direction, mostRecentSample.direction) * Mathf.Deg2Rad;
 
                 // Initialize max and min on first sample.
-                if (i==0)
+                if (first)
                 {
                     positionDeltaMin = positionDelta;
                     positionDeltaMax = positionDelta;
                     directionDeltaMin = directionDelta;
                     directionDeltaMax = directionDelta;
+                    first = false;
                 }
                 else
                 {
@@ -165,9 +166,7 @@ namespace HoloToolkit.Unity
                 }
 
                 positionDeltaMean += positionDelta;
-                directionDeltaMean += directionDelta;
-
-                i++;
+                directionDeltaMean += directionDelta; 
             }
 
             positionDeltaMean = positionDeltaMean / (stabilitySamples.Count - 1);


### PR DESCRIPTION
A queue's ElementAt method iterates internally until it reaches element i. Calling this multiple times within a for loop is very slow.  This commit changes the Queue to a List so that it can iterate more quickly.