### PR TITLE
BUG FIX: SpatialMappingRenderer.cs referenced materials in the wrong location

### DIFF
--- a/Assets/HoloToolkit/SpatialMapping/Scripts/SpatialMappingComponent/SpatialMappingRenderer.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/SpatialMappingComponent/SpatialMappingRenderer.cs
@@ -50,11 +50,11 @@ public class SpatialMappingRenderer : SMBaseAbstract
     {
         base.Start();
 
-        OcclusionMaterial = Resources.Load("HoloToolkit/Occlusion", typeof(Material)) as Material;
+        OcclusionMaterial = Resources.Load("HoloToolkit/SpatialMapping/Materials/Occlusion", typeof(Material)) as Material;
 
         if (RenderingMaterial == null)
         {
-            RenderingMaterial = Resources.Load("HoloToolkit/Wireframe", typeof(Material)) as Material;
+            RenderingMaterial = Resources.Load("HoloToolkit/SpatialMapping/Materials/Wireframe", typeof(Material)) as Material;
         }
     }
 


### PR DESCRIPTION
It seems like some materials got moved and this script wasn't updated to the new location