### PR TITLE
Exposing occlusion material to address issue #58

### DIFF
--- a/Assets/HoloToolkit/SpatialMapping/Editor/SpatialMappingRendererInspector.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Editor/SpatialMappingRendererInspector.cs
@@ -24,8 +24,12 @@ public class SpatialMappingRendererInspector : Editor
         _smRenderer.CurrentRenderingSetting = (SpatialMappingRenderer.RenderingSetting)EditorGUILayout.Popup(new GUIContent("Render Mode"), (int)_smRenderer.CurrentRenderingSetting, renderingSettingChoices);
         switch (_smRenderer.CurrentRenderingSetting)
         {
+            case SpatialMappingRenderer.RenderingSetting.Occlusion:
+                Material occlusionMaterial = _smRenderer.OcclusionMaterial;
+                _smRenderer.OcclusionMaterial = (Material)EditorGUILayout.ObjectField(new GUIContent("Occlusion Material", "Material used for surface occlusion"), (UnityEngine.Object)occlusionMaterial, typeof(Material), false);
+                break;
             case SpatialMappingRenderer.RenderingSetting.Material:
-                Material defaultMaterial = _smRenderer.RenderingMaterial == null ? Resources.Load("HoloToolkit/Wireframe", typeof(Material)) as Material : _smRenderer.RenderingMaterial;
+                Material defaultMaterial = _smRenderer.RenderingMaterial;
                 _smRenderer.RenderingMaterial = (Material)EditorGUILayout.ObjectField(new GUIContent("Render Material", "Material used to render the mesh"), (UnityEngine.Object)defaultMaterial, typeof(Material), false);
                 break;
         }

--- a/Assets/HoloToolkit/SpatialMapping/Scripts/SpatialMappingComponent/SpatialMappingRenderer.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/SpatialMappingComponent/SpatialMappingRenderer.cs
@@ -44,18 +44,21 @@ public class SpatialMappingRenderer : SMBaseAbstract
     /// <summary>
     /// The material used to render the mesh if _currentRenderingSetting is RenderingSetting.Occlusion
     /// </summary>
-    private Material OcclusionMaterial = null;
+    [SerializeField]
+    private Material _occlusionMaterial = null;
+
+    /// <summary>
+    /// The material used to render the mesh if _currentRenderingSetting is RenderingSetting.Occlusion
+    /// </summary>
+    public Material OcclusionMaterial
+    {
+        get { return _occlusionMaterial; }
+        set { _occlusionMaterial = value; ApplyRenderingSettingToCache(); }
+    }
 
     protected override void Start()
     {
         base.Start();
-
-        OcclusionMaterial = Resources.Load("HoloToolkit/SpatialMapping/Materials/Occlusion", typeof(Material)) as Material;
-
-        if (RenderingMaterial == null)
-        {
-            RenderingMaterial = Resources.Load("HoloToolkit/SpatialMapping/Materials/Wireframe", typeof(Material)) as Material;
-        }
     }
 
     /// <summary>
@@ -106,6 +109,7 @@ public class SpatialMappingRenderer : SMBaseAbstract
                 ApplyRenderingSetting(go.GetComponent<MeshRenderer>());
             }
         }
+
         foreach (RemovedSurfaceHolder rsh in RemovedMeshObjects.Values)
         {
             rsh.SetRendererEnabled(CurrentRenderingSetting != RenderingSetting.None);

--- a/README.md
+++ b/README.md
@@ -213,14 +213,16 @@ PlaneFinding addon that can be used to find planar surfaces (ie: walls/floors/ta
 
 ####[SpatialMappingComponent](https://github.com/Microsoft/HoloToolkit-Unity/tree/master/Assets/HoloToolkit/SpatialMapping/Scripts/SpatialMappingComponent)
 A unified set of scripts adhering to best practices for providing physics or rendering support for Spatial Mapping.
-Add a SpatialMappingCollider or SpatialMappingRenderer component onto a GameObject and spatial mapping will just start working
+Add a SpatialMappingCollider or SpatialMappingRenderer component onto a GameObject and spatial mapping will just start working.
 
 #### SpatialMappingRenderer.cs
 Use this script for rendering Spatial Mapping.
 
 **Rendering Mode**: (Default: **Occlusion**). How to render the mesh. Occlusion will cause the mesh to occlude holograms behind it. Material will apply the specified material. None will cause the meshes to not render at all.
 
-**Rendering Material**: (Default: **Wireframe**). The material to render the Spatial Mapping mesh with. This is only relevant when Rendering Mode is set to Material. The default materials are kept in your Resources\HoloToolkit\ folder.
+**Occlusion Material**: (Set this to: **Occlusion**). The material to use for occluding holograms with the spatial mapping mesh. The Occlusion material is located in the HoloToolkit\SpatialMapping\Materials folder.
+
+**Rendering Material**: (Set this to: **Wireframe**). The material to render the Spatial Mapping mesh with. This is only relevant when Rendering Mode is set to Material. The Wireframe material can be found in HoloToolkit\SpatialMapping\Materials folder.
 
 **Freeze Mesh Updates**: (Default: **no**). When enabled, no further updates will be processed. Use this to delay initial starting of Spatial Mapping processing or to stop updates at a certain point.
 


### PR DESCRIPTION
Spatial Mapping renders Hot Pink because it uses Resources.Load to load
materials that do not exist under a resources folder. This change will
still require that the user set the occlusion and render materials
directly (or else they'll see hot pink), but now exposes the 'Occlusion
Material' as a property that can be set in the Inspector.