### PR TITLE
Changed Input Axes to variables to allow for..

### DIFF
--- a/Assets/HoloToolkit/Utilities/Scripts/ManualCameraControl.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/ManualCameraControl.cs
@@ -37,6 +37,14 @@ public class ManualCameraControl : MonoBehaviour
     private bool appHasFocus = true;
     private bool wasLooking = false;
 
+    //exposing variables to editor to all for non-standard unity input configuration
+    public string horizontal = "Horizontal";
+    public string vertical = "Vertical";
+    public string mouseX = "Mouse X";
+    public string mouseY = "Mouse Y";
+    public string lookHorizontal = "LookHorizontal";
+    public string lookVertical = "LookVertical";
+
     private static float InputCurve(float x)
     {
         // smoothing input curve, converts from [-1,1] to [-2,2]
@@ -86,8 +94,8 @@ public class ManualCameraControl : MonoBehaviour
             }
         }
 
-        deltaPosition += InputCurve(Input.GetAxis("Horizontal")) * this.transform.right;
-        deltaPosition += InputCurve(Input.GetAxis("Vertical")) * this.transform.forward;
+        deltaPosition += InputCurve(Input.GetAxis(horizontal)) * this.transform.right;
+        deltaPosition += InputCurve(Input.GetAxis(vertical)) * this.transform.forward;
 
         float accel = Input.GetKey(KeyCode.LeftShift) ? 1.0f : 0.1f;
         return accel * deltaPosition;
@@ -104,8 +112,8 @@ public class ManualCameraControl : MonoBehaviour
             try
             {
                 // Get the axes information from the right stick of X360 controller
-                rot.x += InputCurve(Input.GetAxis("LookVertical")) * inversionFactor;
-                rot.y += InputCurve(Input.GetAxis("LookHorizontal"));
+                rot.x += InputCurve(Input.GetAxis(lookVertical)) * inversionFactor;
+                rot.y += InputCurve(Input.GetAxis(lookHorizontal));
             }
             catch (System.Exception)
             {
@@ -183,8 +191,8 @@ public class ManualCameraControl : MonoBehaviour
         if (UnityEngine.Cursor.lockState == CursorLockMode.Locked)
         {
             Debug.Log("Cursor locked state");
-            mousePositionDelta.x = Input.GetAxis("Mouse X");
-            mousePositionDelta.y = Input.GetAxis("Mouse Y");
+            mousePositionDelta.x = Input.GetAxis(mouseX);
+            mousePositionDelta.y = Input.GetAxis(mouseY);
         }
         else
         {


### PR DESCRIPTION
non standard unity input configurations.

Due to the unique nature of Hololens, none of the projects I have in the works use the standard unity input configuration(partially due to trying
to get a bluetooth game controller to work with unity and hololens, no luck there yet). The changes submitted here allow the user to select which axes to use from the object ManualCameraControl is attached to instead of having to dig into the input settings.