### PR TITLE
Changed Input Axes strings  to variables

### DIFF
--- a/Assets/HoloToolkit/Utilities/Scripts/ManualCameraControl.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/ManualCameraControl.cs
@@ -39,8 +39,8 @@ public class ManualCameraControl : MonoBehaviour
 
     //changed the input axes strings to variables exposing them to the editor for non-standard 
     //unity input configuration
-    public string Horizontal = "Horizontal";
-    public string Vertical = "Vertical";
+    public string MoveHorizontal = "Horizontal";
+    public string MoveVertical = "Vertical";
     public string MouseX = "Mouse X";
     public string MouseY = "Mouse Y";
     // the right stick will need to have settings in the Project Settings->Input setup for a controller
@@ -96,8 +96,8 @@ public class ManualCameraControl : MonoBehaviour
             }
         }
 
-        deltaPosition += InputCurve(Input.GetAxis(Horizontal)) * this.transform.right;
-        deltaPosition += InputCurve(Input.GetAxis(Vertical)) * this.transform.forward;
+        deltaPosition += InputCurve(Input.GetAxis(MoveHorizontal)) * this.transform.right;
+        deltaPosition += InputCurve(Input.GetAxis(MoveVertical)) * this.transform.forward;
 
         float accel = Input.GetKey(KeyCode.LeftShift) ? 1.0f : 0.1f;
         return accel * deltaPosition;

--- a/Assets/HoloToolkit/Utilities/Scripts/ManualCameraControl.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/ManualCameraControl.cs
@@ -37,6 +37,14 @@ public class ManualCameraControl : MonoBehaviour
     private bool appHasFocus = true;
     private bool wasLooking = false;
 
+    //exposing variables to editor to all for non-standard unity input configuration
+    public string horizontal = "Horizontal";
+    public string vertical = "Vertical";
+    public string mouseX = "Mouse X";
+    public string mouseY = "Mouse Y";
+    public string lookHorizontal = "LookHorizontal";
+    public string lookVertical = "LookVertical";
+
     private static float InputCurve(float x)
     {
         // smoothing input curve, converts from [-1,1] to [-2,2]
@@ -86,8 +94,8 @@ public class ManualCameraControl : MonoBehaviour
             }
         }
 
-        deltaPosition += InputCurve(Input.GetAxis("Horizontal")) * this.transform.right;
-        deltaPosition += InputCurve(Input.GetAxis("Vertical")) * this.transform.forward;
+        deltaPosition += InputCurve(Input.GetAxis(horizontal)) * this.transform.right;
+        deltaPosition += InputCurve(Input.GetAxis(vertical)) * this.transform.forward;
 
         float accel = Input.GetKey(KeyCode.LeftShift) ? 1.0f : 0.1f;
         return accel * deltaPosition;
@@ -104,8 +112,8 @@ public class ManualCameraControl : MonoBehaviour
             try
             {
                 // Get the axes information from the right stick of X360 controller
-                rot.x += InputCurve(Input.GetAxis("LookVertical")) * inversionFactor;
-                rot.y += InputCurve(Input.GetAxis("LookHorizontal"));
+                rot.x += InputCurve(Input.GetAxis(lookVertical)) * inversionFactor;
+                rot.y += InputCurve(Input.GetAxis(lookHorizontal));
             }
             catch (System.Exception)
             {
@@ -183,8 +191,8 @@ public class ManualCameraControl : MonoBehaviour
         if (UnityEngine.Cursor.lockState == CursorLockMode.Locked)
         {
             Debug.Log("Cursor locked state");
-            mousePositionDelta.x = Input.GetAxis("Mouse X");
-            mousePositionDelta.y = Input.GetAxis("Mouse Y");
+            mousePositionDelta.x = Input.GetAxis(mouseX);
+            mousePositionDelta.y = Input.GetAxis(mouseY);
         }
         else
         {

--- a/Assets/HoloToolkit/Utilities/Scripts/ManualCameraControl.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/ManualCameraControl.cs
@@ -37,13 +37,21 @@ public class ManualCameraControl : MonoBehaviour
     private bool appHasFocus = true;
     private bool wasLooking = false;
 
+    //Input axes  to coordinate with the Input Manager (Project Settings -> Input)
     [Tooltip("Horizontal movement Axis ")]
+    public string MoveHorizontal = "Horizontal"; //Horizontal movement string for keyboard and left stick of game controller
     [Tooltip("Vertical movement Axis ")]
+    public string MoveVertical = "Vertical";  //Vertical movement string for keyboard and left stick of game controller 
     [Tooltip("Mouse Movement X-axis")] 
+    public string MouseX = "Mouse X"; // Mouse movement string for the x-axis
     [Tooltip("Mouse Movement Y-axis")]
+    public string MouseY = "Mouse Y"; // Mouse movement string for the y-axis
     
+    // the right stick has no default settings in the Input Manager and will need to be setup for a game controller to look
     [Tooltip("Look Horizontal Axis - Right Stick On Controller")]
+    public string LookHorizontal = "LookHorizontal";  //Look horizontal string for right stick of game controller
     [Tooltip("Look Vertical Axis - Right Stick On Controller ")]
+    public string LookVertical = "LookVertical"; //Look vertical string for right stick of game controller
 
     private static float InputCurve(float x)
     {

--- a/Assets/HoloToolkit/Utilities/Scripts/ManualCameraControl.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/ManualCameraControl.cs
@@ -37,15 +37,13 @@ public class ManualCameraControl : MonoBehaviour
     private bool appHasFocus = true;
     private bool wasLooking = false;
 
-    //changed the input axes strings to variables exposing them to the editor for non-standard 
-    //unity input configuration
-    public string MoveHorizontal = "Horizontal";
-    public string MoveVertical = "Vertical";
-    public string MouseX = "Mouse X";
-    public string MouseY = "Mouse Y";
-    // the right stick will need to have settings in the Project Settings->Input setup for a controller
-    public string LookHorizontal = "LookHorizontal";
-    public string LookVertical = "LookVertical";
+    [Tooltip("Horizontal movement Axis ")]
+    [Tooltip("Vertical movement Axis ")]
+    [Tooltip("Mouse Movement X-axis")] 
+    [Tooltip("Mouse Movement Y-axis")]
+    
+    [Tooltip("Look Horizontal Axis - Right Stick On Controller")]
+    [Tooltip("Look Vertical Axis - Right Stick On Controller ")]
 
     private static float InputCurve(float x)
     {

--- a/Assets/HoloToolkit/Utilities/Scripts/ManualCameraControl.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/ManualCameraControl.cs
@@ -37,13 +37,15 @@ public class ManualCameraControl : MonoBehaviour
     private bool appHasFocus = true;
     private bool wasLooking = false;
 
-    //exposing variables to editor to all for non-standard unity input configuration
-    public string horizontal = "Horizontal";
-    public string vertical = "Vertical";
-    public string mouseX = "Mouse X";
-    public string mouseY = "Mouse Y";
-    public string lookHorizontal = "LookHorizontal";
-    public string lookVertical = "LookVertical";
+    //changed the input axes strings to variables exposing them to the editor for non-standard 
+    //unity input configuration
+    public string Horizontal = "Horizontal";
+    public string Vertical = "Vertical";
+    public string MouseX = "Mouse X";
+    public string MouseY = "Mouse Y";
+    // the right stick will need to have settings in the Project Settings->Input setup for a controller
+    public string LookHorizontal = "LookHorizontal";
+    public string LookVertical = "LookVertical";
 
     private static float InputCurve(float x)
     {
@@ -94,8 +96,8 @@ public class ManualCameraControl : MonoBehaviour
             }
         }
 
-        deltaPosition += InputCurve(Input.GetAxis(horizontal)) * this.transform.right;
-        deltaPosition += InputCurve(Input.GetAxis(vertical)) * this.transform.forward;
+        deltaPosition += InputCurve(Input.GetAxis(Horizontal)) * this.transform.right;
+        deltaPosition += InputCurve(Input.GetAxis(Vertical)) * this.transform.forward;
 
         float accel = Input.GetKey(KeyCode.LeftShift) ? 1.0f : 0.1f;
         return accel * deltaPosition;
@@ -112,8 +114,8 @@ public class ManualCameraControl : MonoBehaviour
             try
             {
                 // Get the axes information from the right stick of X360 controller
-                rot.x += InputCurve(Input.GetAxis(lookVertical)) * inversionFactor;
-                rot.y += InputCurve(Input.GetAxis(lookHorizontal));
+                rot.x += InputCurve(Input.GetAxis(LookVertical)) * inversionFactor;
+                rot.y += InputCurve(Input.GetAxis(LookHorizontal));
             }
             catch (System.Exception)
             {
@@ -191,8 +193,8 @@ public class ManualCameraControl : MonoBehaviour
         if (UnityEngine.Cursor.lockState == CursorLockMode.Locked)
         {
             Debug.Log("Cursor locked state");
-            mousePositionDelta.x = Input.GetAxis(mouseX);
-            mousePositionDelta.y = Input.GetAxis(mouseY);
+            mousePositionDelta.x = Input.GetAxis(MouseX);
+            mousePositionDelta.y = Input.GetAxis(MouseY);
         }
         else
         {


### PR DESCRIPTION
exposing them to the editor for non- standard unity input configuration. 

The right thumb stick will need to have axes created in Project Settings -> Input in unity to work correctly.

Due to Hololens unique nature, none of my projects have had the standard input setup so far. Putting in this class would, at least temporarily break things. These changes mostly fix that issue. 