### PR TITLE
Add a SpeakHtml method to TTS

### DIFF
--- a/Assets/HoloToolkit/Utilities/Scripts/TextToSpeechManager.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/TextToSpeechManager.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 using System;
+using System.Text;
+using System.Text.RegularExpressions;
 using UnityEngine;
 
 #if WINDOWS_UWP
@@ -323,6 +325,55 @@ namespace HoloToolkit.Unity
             #else
             LogSpeech(text);
             #endif
+        }
+
+        /// <summary>
+        /// RE for stripping HTML
+        /// </summary>
+        //static Regex _htmlRegex = new Regex("<.*?>", RegexOptions.SingleLine);
+        private static readonly Regex _stripTagsRegex = new Regex(@"</?\w+((\s+\w+(\s*=\s*(?:"".*?""|'.*?'|[^'"">\s]+))?)+\s*|\s*)/?>", RegexOptions.Singleline);
+
+        /// <summary>
+        /// Remove HTML from string..
+        /// </summary>
+        private static string StripTags(string source)
+        {
+            StringBuilder sb = new StringBuilder(source);
+            // Strip whitespace
+            sb.Replace("\r", " ");
+            sb.Replace("\n", " ");
+            sb.Replace("\t", String.Empty);
+
+            string[] Encoded = { "&nbsp;", "&amp;", "&quot;", "&lt;", "&gt;", "&copy;" };
+            string[] Real = { " ", "&", "\"", "<", ">", "Copyright" };
+            for (int idx = 0; idx < Encoded.Length; idx++)
+            {
+                sb.Replace(Encoded[idx], Real[idx]);
+            }
+
+            // Insert newlines to case pauses in the reading
+            sb.Replace("<h1", "\n\n<h1");
+            sb.Replace("</h1", "\n\n</h1");
+            sb.Replace("<h2", "\n\n<h2");
+            sb.Replace("</h2", "\n\n</h2");
+            sb.Replace("<h3", "\n\n<h3");
+            sb.Replace("</h3", "\n\n</h3");
+            sb.Replace("<h4", "\n\n<h4");
+            sb.Replace("</h4", "\n\n</h4");
+            sb.Replace("<h5", "\n\n<h5");
+            sb.Replace("</h5", "\n\n</h5");
+            sb.Replace("<h6", "\n\n<h6");
+            sb.Replace("</h6", "\n\n</h6");
+            sb.Replace("<br", "\n<br");
+            sb.Replace("<p ", "\n<p ");
+
+            var result = sb.ToString();
+            return _stripTagsRegex.Replace(result, string.Empty);
+        }
+
+        public void SpeakHtml(string html)
+        {
+            SpeakText(StripTags(html));
         }
     }
 }

--- a/Assets/HoloToolkit/Utilities/Tests/TextToSpeechManager.unity
+++ b/Assets/HoloToolkit/Utilities/Tests/TextToSpeechManager.unity
@@ -388,54 +388,6 @@ Light:
   m_BounceIntensity: 1
   m_ShadowRadius: 0
   m_ShadowAngle: 0
---- !u!1 &478672352
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1000012943254746, guid: b2db04283121ca74495c2ee000fb4243,
-    type: 2}
-  m_PrefabInternal: {fileID: 1484279150}
-  serializedVersion: 4
-  m_Component:
-  - 4: {fileID: 478672354}
-  - 114: {fileID: 478672353}
-  m_Layer: 2
-  m_Name: Cursor
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &478672353
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 114000014146313642, guid: b2db04283121ca74495c2ee000fb4243,
-    type: 2}
-  m_PrefabInternal: {fileID: 1484279150}
-  m_GameObject: {fileID: 478672352}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 37be0deba90cea9489f9a6e0acdc84df, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  CursorOnHolograms: {fileID: 734504339}
-  CursorOffHolograms: {fileID: 492701916}
-  DistanceFromCollision: 0.01
---- !u!4 &478672354
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 4000013535415816, guid: b2db04283121ca74495c2ee000fb4243,
-    type: 2}
-  m_PrefabInternal: {fileID: 1484279150}
-  m_GameObject: {fileID: 478672352}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 734504342}
-  - {fileID: 492701920}
-  m_Father: {fileID: 0}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &488360706
 GameObject:
   m_ObjectHideFlags: 0
@@ -515,91 +467,6 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 488360706}
---- !u!1 &492701916
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1000013615056792, guid: b2db04283121ca74495c2ee000fb4243,
-    type: 2}
-  m_PrefabInternal: {fileID: 1484279150}
-  serializedVersion: 4
-  m_Component:
-  - 4: {fileID: 492701920}
-  - 33: {fileID: 492701919}
-  - 135: {fileID: 492701918}
-  - 23: {fileID: 492701917}
-  m_Layer: 2
-  m_Name: CursorOffHolograms
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!23 &492701917
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 23000011471158336, guid: b2db04283121ca74495c2ee000fb4243,
-    type: 2}
-  m_PrefabInternal: {fileID: 1484279150}
-  m_GameObject: {fileID: 492701916}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
-  m_SubsetIndices: 
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 1
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
---- !u!135 &492701918
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 135000012439094316, guid: b2db04283121ca74495c2ee000fb4243,
-    type: 2}
-  m_PrefabInternal: {fileID: 1484279150}
-  m_GameObject: {fileID: 492701916}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.5
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!33 &492701919
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 33000010463283372, guid: b2db04283121ca74495c2ee000fb4243,
-    type: 2}
-  m_PrefabInternal: {fileID: 1484279150}
-  m_GameObject: {fileID: 492701916}
-  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &492701920
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 4000013144497514, guid: b2db04283121ca74495c2ee000fb4243,
-    type: 2}
-  m_PrefabInternal: {fileID: 1484279150}
-  m_GameObject: {fileID: 492701916}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.005, y: 0.005, z: 0.005}
-  m_Children:
-  - {fileID: 1342176771}
-  m_Father: {fileID: 478672354}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &661260205
 GameObject:
   m_ObjectHideFlags: 0
@@ -662,76 +529,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &734504339
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1000012100030190, guid: b2db04283121ca74495c2ee000fb4243,
-    type: 2}
-  m_PrefabInternal: {fileID: 1484279150}
-  serializedVersion: 4
-  m_Component:
-  - 4: {fileID: 734504342}
-  - 33: {fileID: 734504341}
-  - 23: {fileID: 734504340}
-  m_Layer: 2
-  m_Name: CursorOnHolograms
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!23 &734504340
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 23000013452343876, guid: b2db04283121ca74495c2ee000fb4243,
-    type: 2}
-  m_PrefabInternal: {fileID: 1484279150}
-  m_GameObject: {fileID: 734504339}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_Materials:
-  - {fileID: 2100000, guid: a2c9c4679b0c3cf47b3ba3a449c985d7, type: 2}
-  m_SubsetIndices: 
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
---- !u!33 &734504341
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 33000011299448354, guid: b2db04283121ca74495c2ee000fb4243,
-    type: 2}
-  m_PrefabInternal: {fileID: 1484279150}
-  m_GameObject: {fileID: 734504339}
-  m_Mesh: {fileID: 4300000, guid: c1000081192be7347a0ad0c380ed6171, type: 3}
---- !u!4 &734504342
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 4000011283192616, guid: b2db04283121ca74495c2ee000fb4243,
-    type: 2}
-  m_PrefabInternal: {fileID: 1484279150}
-  m_GameObject: {fileID: 734504339}
-  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1.15, y: 1.15, z: 2.5}
-  m_Children: []
-  m_Father: {fileID: 478672354}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
 --- !u!1 &770488534
 GameObject:
   m_ObjectHideFlags: 0
@@ -869,71 +666,6 @@ Transform:
   m_Father: {fileID: 1870424961}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1342176770
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1000013763932778, guid: b2db04283121ca74495c2ee000fb4243,
-    type: 2}
-  m_PrefabInternal: {fileID: 1484279150}
-  serializedVersion: 4
-  m_Component:
-  - 4: {fileID: 1342176771}
-  - 108: {fileID: 1342176772}
-  m_Layer: 2
-  m_Name: Point light
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1342176771
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 4000010267160112, guid: b2db04283121ca74495c2ee000fb4243,
-    type: 2}
-  m_PrefabInternal: {fileID: 1484279150}
-  m_GameObject: {fileID: 1342176770}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 492701920}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!108 &1342176772
-Light:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 108000011213487996, guid: b2db04283121ca74495c2ee000fb4243,
-    type: 2}
-  m_PrefabInternal: {fileID: 1484279150}
-  m_GameObject: {fileID: 1342176770}
-  m_Enabled: 1
-  serializedVersion: 7
-  m_Type: 2
-  m_Color: {r: 0.8039216, g: 0.6431373, b: 0.9529412, a: 1}
-  m_Intensity: 1
-  m_Range: 0.05
-  m_SpotAngle: 30
-  m_CookieSize: 10
-  m_Shadows:
-    m_Type: 0
-    m_Resolution: -1
-    m_Strength: 1
-    m_Bias: 0.05
-    m_NormalBias: 0.4
-    m_NearPlane: 0.2
-  m_Cookie: {fileID: 0}
-  m_DrawHalo: 1
-  m_Flare: {fileID: 0}
-  m_RenderMode: 0
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_Lightmapping: 4
-  m_AreaSize: {x: 1, y: 1}
-  m_BounceIntensity: 1
-  m_ShadowRadius: 0
-  m_ShadowAngle: 0
 --- !u!1 &1387631413
 GameObject:
   m_ObjectHideFlags: 0
@@ -1037,7 +769,6 @@ Prefab:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: b2db04283121ca74495c2ee000fb4243, type: 2}
-  m_RootGameObject: {fileID: 478672352}
   m_IsPrefabParent: 0
 --- !u!1 &1655140847
 GameObject:
@@ -1053,7 +784,7 @@ GameObject:
   - 82: {fileID: 1655140849}
   - 114: {fileID: 1655140848}
   m_Layer: 0
-  m_Name: Cube3
+  m_Name: Cube3_HTML
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/Assets/HoloToolkit/Utilities/Tests/TextToSpeechManagerTest.cs
+++ b/Assets/HoloToolkit/Utilities/Tests/TextToSpeechManagerTest.cs
@@ -39,7 +39,14 @@ public class TextToSpeechManagerTest : MonoBehaviour
             // This voice will appear to emanate from the object.
             if (tts != null)
             {
-                tts.SpeakText("This voice should sound like it's coming from the object you clicked. Feel free to walk around and listen from different angles.");
+                if (obj.name.EndsWith("HTML"))
+                {
+                    tts.SpeakHtml("<p>This voice should sound like it's coming from the object you clicked. Unlike the text on the other two boxes the source text is HTML formatted. But you shouldn't notice any difference in the speech.</p>");
+                }
+                else
+                {
+                    tts.SpeakText("This voice should sound like it's coming from the object you clicked. Feel free to walk around and listen from different angles.");
+                }
             }
         }
     }


### PR DESCRIPTION
Add a basic ability to parse and speak HTML. Parsing of the HTML is sufficient, but could certainly be improved over time. Currently ensures paragraphs/headings are correctly separated that encoded characters are converted to their txt form and tags are removed.

The end resuly is a txt file that is then spoken using the existing SpeakText method.