### PR TITLE
Fix for MSBuild .sln path argument to allow for directories with spaces.

### DIFF
--- a/Assets/HoloToolkit/Build/Editor/BuildDeployTools.cs
+++ b/Assets/HoloToolkit/Build/Editor/BuildDeployTools.cs
@@ -106,7 +106,7 @@ namespace HoloToolkit.Unity
             pinfo.FileName = vs;
             pinfo.UseShellExecute = false;
             string buildType = forceRebuildAppx ? "Rebuild" : "Build";
-            pinfo.Arguments = string.Format("{0} /t:{2} /p:Configuration={1} /p:Platform=x86", solutionProjectPath, buildConfig, buildType);
+            pinfo.Arguments = string.Format("\"{0}\" /t:{2} /p:Configuration={1} /p:Platform=x86", solutionProjectPath, buildConfig, buildType);
             var p = new System.Diagnostics.Process();
 
             Debug.Log(vs + " " + pinfo.Arguments);


### PR DESCRIPTION
Having spaces in your solution's directory resulted in MSBuild Error (Code = 1) when building your appx. Enclosed the path in escaped quotes to resolve the issue.