### PR TITLE
Build window - fix for potential install/launch issue

### DIFF
--- a/Assets/HoloToolkit/Build/Editor/BuildDeployPortal.cs
+++ b/Assets/HoloToolkit/Build/Editor/BuildDeployPortal.cs
@@ -170,7 +170,7 @@ namespace HoloToolkit.Unity
                 AppList appList = JsonUtility.FromJson<AppList>(appListJSON);
                 for (int i = 0; i < appList.InstalledPackages.Length; ++i)
                 {
-                    string appName = appList.InstalledPackages[i].PackageFullName;
+                    string appName = appList.InstalledPackages[i].Name;
                     if (appName.Contains(baseAppName))
                     {
                         return appList.InstalledPackages[i];


### PR DESCRIPTION
Switched to using the app name (rather than package name) when looking for the app in the app list (if the package name didn't contain the app name, this would fail - this is a more correct way to do it)