### PR TITLE
Changes to HoloToolkit menu for setting project / scene defaults

### DIFF
--- a/Assets/HoloToolkit/Utilities/Editor/ConfigureMenu.cs
+++ b/Assets/HoloToolkit/Utilities/Editor/ConfigureMenu.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using UnityEditor;
@@ -22,34 +23,186 @@ namespace HoloToolkit.Unity
             Application.OpenURL("https://developer.microsoft.com/en-us/windows/holographic/unity_development_overview#Configuring_a_Unity_project_for_HoloLens");
         }
 
+        [MenuItem("HoloToolkit/Configure/Apply All HoloLens Settings", priority = 0)]
+        public static void ApplyAllSettings()
+        {
+            var output = new StringBuilder();
+            ApplySceneSettingsInternal(output);
+
+
+            var reload = ApplyProjectSettingsInternal(output);
+
+            EditorUtility.DisplayDialog("Results", output.ToString(), "Ok");
+
+            if (reload)
+            {
+                PromptForReload();
+            }
+        }
+
+
+        private static void ApplySceneSettingsInternal(StringBuilder output)
+        {
+            //todo if we find more than one camera, hololens will always use MainCamera (should)
+            //additional cameras could be used from a RenderTexture, etc. Should we warn?
+
+            output.AppendLine("** Checking Camera Settings");
+            Camera[] cameras = new Camera[Camera.allCamerasCount];
+            Camera.GetAllCameras(cameras);
+
+            if (Camera.main == null)
+            {
+                output.AppendLine(@"Could not apply camera settings - no camera tagged with ""MainCamera""");
+                return;
+            }
+
+            SetCameraDefaults(Camera.main, true, output);
+
+            //All done with MainCamera
+            cameras = cameras.Where(o => o != Camera.main).ToArray();
+
+            //Check remaining cameras
+            if (cameras.Length > 0)
+            {
+                foreach (var camera in cameras)
+                {
+                    Debug.Log(camera);
+                    var cameraDetails = string.Format("Update this camera for HoloLens defaults? \r\nThis will set position to 0,0,0 (on MainCamera only) and background color to Clear Flags:Solid color(Black). \r\n \r\n---------------\r\nName: {0} \r\nPosition: {1}\r\nTag: {2}\r\n---------------",
+                        camera.name, camera.transform.position, camera.tag);
+                    if (EditorUtility.DisplayDialog("Multiple Cameras Detected",
+    cameraDetails, "Yes", "No"))
+                    {
+                        //It's not main so we won't touch posiution
+                        SetCameraDefaults(camera, false, output);
+                    }
+                }
+            }
+            output.AppendLine();
+        }
+
+        /// <summary>
+        /// Modified camera settings to the HoloLens recommended defaults
+        /// </summary>
+        /// <param name="camera">Camera to update</param>
+        /// <param name="output">Output log</param>
+        private static void SetCameraDefaults(Camera camera, bool isMain, StringBuilder output)
+        {
+            output.AppendLine(string.Format("     Checking camera {0} at {1}", camera.name, camera.transform.position.ToString()));
+
+            if (isMain)
+            {
+                output.Append("     Checking position:");
+                if (camera.transform.position != Vector3.zero)
+                {
+                    camera.transform.position = Vector3.zero;
+                    output.AppendLine("  Updated position");
+                }
+                else
+                {
+                    output.AppendLine("  OK");
+                }
+            }
+            else
+            {
+                output.AppendLine("     Position ignored, not the MainCamera");
+            }
+
+            output.Append("     Checking Near Clip Plane is .85:");
+            if (camera.nearClipPlane != 0.85f)
+            {
+                camera.nearClipPlane = 0.85f;
+                output.AppendLine("  Updated");
+            }
+            else
+            {
+                output.AppendLine("  OK");
+            }
+
+            output.Append("     Checking Clear Flags are Black:");
+            if (camera.clearFlags != CameraClearFlags.Color)
+            {
+                camera.clearFlags = CameraClearFlags.Color;
+                camera.backgroundColor = Color.black;
+                output.AppendLine("  Updated");
+            }
+            else
+            {
+                output.AppendLine("  OK");
+            }
+            output.AppendLine();
+        }
+
         /// <summary>
         /// Applies recommended scene settings to the current scenes
         /// </summary>
         [MenuItem("HoloToolkit/Configure/Apply HoloLens Scene Settings", priority = 0)]
         public static void ApplySceneSettings()
         {
-            if (Camera.main == null)
-            {
-                Debug.LogWarning(@"Could not apply settings - no camera tagged with ""MainCamera""");
-                return;
-            }
-
-            Camera.main.transform.position = Vector3.zero;
-            Camera.main.clearFlags = CameraClearFlags.SolidColor;
-            Camera.main.backgroundColor = Color.black;
-            Camera.main.nearClipPlane = 0.85f;
+            var output = new StringBuilder();
+            ApplySceneSettingsInternal(output);
+            EditorUtility.DisplayDialog("Results", output.ToString(), "Ok");
         }
 
-        /// <summary>
-        /// Applies recommended project settings to the current project
-        /// </summary>
-        [MenuItem("HoloToolkit/Configure/Apply HoloLens Project Settings", priority = 0)]
-        public static void ApplyProjectSettings()
+        private static bool ApplyProjectSettingsInternal(StringBuilder output)
         {
             // Build settings
-            EditorUserBuildSettings.SwitchActiveBuildTarget(BuildTarget.WSAPlayer);
-            EditorUserBuildSettings.wsaSDK = WSASDK.UWP;
-            EditorUserBuildSettings.wsaUWPBuildType = WSAUWPBuildType.D3D;
+            output.AppendLine("** Checking Build Settings for WSA");
+            bool isWsa = EditorUserBuildSettings.activeBuildTarget == BuildTarget.WSAPlayer;
+            bool isWsaSdk = EditorUserBuildSettings.wsaSDK == WSASDK.UWP;
+            bool isDirect3D = EditorUserBuildSettings.wsaUWPBuildType == WSAUWPBuildType.D3D;
+            bool isUnityCSharpProjs = EditorUserBuildSettings.wsaGenerateReferenceProjects;
+
+            output.Append("     Build Target WSA:");
+            if (!isWsa)
+            {
+                EditorUserBuildSettings.SwitchActiveBuildTarget(BuildTarget.WSAPlayer);
+                output.AppendLine("  Updated");
+            }
+            else
+            {
+                output.AppendLine("  OK");
+            }
+
+            output.Append("     Targeting Windows 10:");
+            if (!isWsaSdk)
+            {
+                EditorUserBuildSettings.wsaSDK = WSASDK.UWP;
+                output.AppendLine("  Updated");
+            }
+            else
+            {
+                output.AppendLine("  OK");
+            }
+
+            //Says Windows Phone but this is 'device' default, not phone.
+            //The default of 'Local Machine' doesn't for for us, since we're 
+            //not developing ON a HoloLens but for a HoloLens
+            Debug.Log("wsaBuildAndRunDeployTarget:" + EditorUserBuildSettings.wsaBuildAndRunDeployTarget);
+            EditorUserBuildSettings.wsaBuildAndRunDeployTarget = WSABuildAndRunDeployTarget.WindowsPhone;
+
+            output.Append("     Targeting Direct3D (Slight perf over XAML):");
+            if (!isDirect3D)
+            {
+                EditorUserBuildSettings.wsaUWPBuildType = WSAUWPBuildType.D3D;
+                output.AppendLine("  Updated");
+            }
+            else
+            {
+                output.AppendLine("  OK");
+            }
+            output.Append("     Generate Unity C# Projects:");
+
+            if (!isUnityCSharpProjs)
+            {
+                EditorUserBuildSettings.wsaGenerateReferenceProjects = true;
+                output.AppendLine("  Updated");
+            }
+            else
+            {
+                output.AppendLine("  OK");
+            }
+
+            output.AppendLine();
 
             // See the blow notes for why text asset serialization is required
             if (EditorSettings.serializationMode != SerializationMode.ForceText)
@@ -61,130 +214,196 @@ namespace HoloToolkit.Unity
                 // NOTE: There is no current way to change the default quality setting from script
 
                 string title = "Updates require text serialization of assets";
-                string message = "Unity doesn't provide apis for updating the default quality or enabling VR support.\n\n" +
-                    "Is it ok if we force text serialization of assets so that we can modify the properties directly?";
+                string message = "Unity doesn't provide apis for updating the default quality.\n\n" +
+                    "Is it ok if we force text serialization of assets so that we can modify the properties of the 'Project Settings/Quality' directly? Text serialization is typically better for source control as well, enabling easier diffs between versions.";
 
                 bool forceText = EditorUtility.DisplayDialog(title, message, "Yes", "No");
                 if (!forceText)
-                    return;
+                {
+                    output.AppendLine("Project settings cancelled.");
+                    return false;
+                }
 
-                EditorSettings.serializationMode = SerializationMode.ForceText;
+                output.Append("** Checking Editor Serialization Mode:");
+                if (EditorSettings.serializationMode != SerializationMode.ForceText)
+                {
+                    EditorSettings.serializationMode = SerializationMode.ForceText;
+                    output.AppendLine("  Updated");
+                }
+                else
+                {
+                    output.AppendLine("  OK");
+                }
+                output.AppendLine();
             }
 
-            SetFastestDefaultQuality();
-            EnableVirtualReality();
+            var reload = SetFastestDefaultQuality(output);
 
+            //pick up the reload flag here if we need it too
+            reload |= EnableVirtualReality(output);
+
+            return reload;
+
+        }
+        /// <summary>
+        /// Applies recommended project settings to the current project
+        /// </summary>
+        [MenuItem("HoloToolkit/Configure/Apply HoloLens Project Settings", priority = 0)]
+        public static void ApplyProjectSettings()
+        {
+            var output = new StringBuilder();
+
+            var reload = ApplyProjectSettingsInternal(output);
+
+            EditorUtility.DisplayDialog("Results", output.ToString(), "Ok");
+
+            if (reload)
+            {
+                PromptForReload();
+            }
+        }
+
+        private static void PromptForReload()
+        {
             // Since we went behind Unity's back to tweak some settings we 
             // need to reload the project to have them take effect
             bool canReload = EditorUtility.DisplayDialog(
                 "Project reload required!",
-                "Some changes require a project reload to take effect.\n\nReload now?",
+                "The default quality level change and/or the Windows Store VR change requires a project reload to take effect.\n\nReload now?",
                 "Yes", "No");
 
             if (canReload)
             {
-                string projectPath = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
-                EditorApplication.OpenProject(projectPath);
+                EditorApplication.OpenProject(Application.dataPath + "/..");
             }
         }
 
         /// <summary>
-        /// Modifies the WSA default quality setting to the fastest
+        /// Modifies the WSA default quality setting to the fastest.
         /// </summary>
-        private static void SetFastestDefaultQuality()
+        /// <param name="output"></param>
+        /// <returns>True is the project requires a reload because of quality settings change. False if the project quality level is already set to 'Fastest' </returns>
+        private static bool SetFastestDefaultQuality(StringBuilder output)
         {
             try
             {
+                output.Append("** Checking Quality Settings @ 'Fastest':");
                 // Find the WSA element under the platform quality list and replace it's value with 0
                 string settingsPath = "ProjectSettings/QualitySettings.asset";
+                string matchPatternFastest = "m_PerPlatformDefaultQuality.*Windows Store Apps: 0";
                 string matchPattern = @"(m_PerPlatformDefaultQuality.*Windows Store Apps:) (\d+)";
                 string replacePattern = @"$1 0";
 
                 string settings = File.ReadAllText(settingsPath);
-                settings = Regex.Replace(settings, matchPattern, replacePattern, RegexOptions.Singleline);
 
-                File.WriteAllText(settingsPath, settings);
+                //If quality level not already set to "Windows Store Apps: 0"
+                //We use SingleLine mode to make . match any char including newlines
+                var match = Regex.Match(settings, matchPatternFastest, RegexOptions.Singleline);
+
+                if (!match.Success)
+                {
+                    //Write updated settings
+                    settings = Regex.Replace(settings, matchPattern, replacePattern, RegexOptions.Singleline);
+                    File.WriteAllText(settingsPath, settings);
+                    output.AppendLine("  Updated");
+
+                    //Project reload required
+                    return true;
+                }
+                else
+                {
+                    output.AppendLine("  OK");
+                }
+                output.AppendLine();
             }
             catch (Exception e)
             {
                 Debug.LogException(e);
             }
-        }
 
+            //No reload required
+            return false;
+        }
+    
         /// <summary>
         /// Enables virtual reality for WSA and ensures HoloLens is in the supported SDKs.
         /// </summary>
-        private static void EnableVirtualReality()
+        private static bool EnableVirtualReality(StringBuilder output)
         {
-            try
+            output.AppendLine("** Checking VR Settings for WSA");
+            //bool vrSupported = PlayerSettings.virtualRealitySupported = true;
+            //Warning, not public yet. May change. Above API setting will work if we assume
+            //WSA platform is active build target, but if they don't have WSA players installed
+            //then this be an installed option. Not a problem in HoloLens Technical Preview
+            //but could be if run on any other version or in the future.
+            bool vrSupported = UnityEditorInternal.VR.VREditor.GetVREnabled(BuildTargetGroup.WSA);
+
+            output.Append("     VR Enabled: ");
+            //enable VR
+            if (!vrSupported)
             {
-                // Grab the text from the project settings asset file
-                string settingsPath = "ProjectSettings/ProjectSettings.asset";
-                string settings = File.ReadAllText(settingsPath);
+                //PlayerSettings.virtualRealitySupported = true;
+                UnityEditorInternal.VR.VREditor.SetVREnabled(BuildTargetGroup.WSA, true);
 
-                // Set VR for WSA to 1
-                string matchPattern = @"(Metro::VR::enable:) (\d+)";
-                string replacePattern = @"$1 1";
-                settings = Regex.Replace(settings, matchPattern, replacePattern, RegexOptions.Singleline);
+                output.AppendLine("  Updated");
+            }
+            else
+            {
+                output.AppendLine("  OK");
+            }
 
-                // This is a bit more complex, we're looking for the WSA list of enabled VR devices, then
-                // ensuring that the HoloLens is in that list
-                bool foundDevices = false;
-                bool foundHoloLens = false;
+            //Check if Windows Holographic is enabled for WSA
+            bool windowsHolographic = false;
 
-                var builder = new StringBuilder(); // Used to build the final output
-                string[] lines = settings.Split(new char[] { '\n' });
-                for (int i = 0; i < lines.Length; ++i)
+            var vrDevices = UnityEditorInternal.VR.VREditor.GetVREnabledDevices(BuildTargetGroup.WSA);
+            foreach (var device in vrDevices)
+            {
+                //Debug.Log(device);
+                if (device == "HoloLens")
                 {
-                    string line = lines[i];
+                    windowsHolographic = true;
+                }
+            }
 
-                    // Look for the enabled Devices list
-                    if (!foundDevices)
+            if (!windowsHolographic)
+            {
+                //Cover the case of someone accidentally deleting Windows Holographic
+                Debug.Log("Enumerating installed VR Device Info (HoloLens ie Windows Holographic wasn't found under Virtual Reality SDKs)");
+                bool vrHoloLensFound = false;
+
+                //Check to see if we have Windows HoloGraphic installed (keyname is HoloLens)
+                foreach (var item in UnityEditorInternal.VR.VREditor.GetAllVRDeviceInfo(BuildTargetGroup.WSA))
+                {
+                    Debug.Log(string.Format("deviceNameKey:{0} deviceNameUI:{1}", item.deviceNameKey, item.deviceNameUI));
+                    Debug.Log(item);
+                    if (item.deviceNameKey == "HoloLens")
                     {
-                        if (line.Contains("Metro::VR::enabledDevices:"))
-                        {
-                            // Clear the empty array symbols if any
-                            line = line.Replace(" []", "");
-                            foundDevices = true;
-                        }
-
+                        vrHoloLensFound = true;
                     }
-
-                    // Once we've found the list look for HoloLens or the next non element
-                    else if (!foundHoloLens)
-                    {
-                        // If this isn't an element in the device list
-                        if (!line.Contains("-"))
-                        {
-                            // add the hololens element, and mark it found
-                            builder.Append("  - HoloLens\n");
-                            foundHoloLens = true;
-                        }
-
-                        // Otherwise test if this is the hololens device
-                        else if (line.Contains("HoloLens"))
-                        {
-                            foundHoloLens = true;
-                        }
-                    }
-
-                    builder.Append(line);
-
-                    // Write out a \n for all but the last line
-                    // NOTE: Specifically preserving unix line endings by avoiding StringBuilder.AppendLine
-                    if (i != lines.Length - 1)
-                        builder.Append('\n');
                 }
 
-                // Capture the final string
-                settings = builder.ToString();
+                if (vrHoloLensFound)
+                {
+                    Debug.Log("Setting enabled VR device to HoloLens");
+                    //Yep it's installed, for some reason was removed or not added to list.
+                    UnityEditorInternal.VR.VREditor.SetVREnabledDevices(BuildTargetGroup.WSA, new string[] { "HoloLens" });
 
-                File.WriteAllText(settingsPath, settings);
+                    //This change isn't picked up immediately in the UI, reload project to be sure.
+                    return true;
+                }
+                else
+                {
+                    var noWindowsHolographic = "'Windows Holographic' (HoloLens) was not found as a VR type in the Windows 10 Player settings. This should be listed there, ensure you are using a supported version of Unity for the HoloLens. This process will continue, but when it's done verify in your Player Settings (File-Build Settings, click on Windows Store, ensure Windows 10 is selected in the dropdown, and click Player Settings. Then on the right in 'Other Settings' ensure VR Supported is checked off and Windows Holographic shows up in the options. If not either the SDK name has changed or you possibly have a version of Unity that doesn't support the HoloLens.";
+                    output.AppendLine(noWindowsHolographic);
+                }
             }
-            catch (Exception e)
+            else
             {
-                Debug.LogException(e);
+                output.AppendLine("     Windows Holographic SDK Present: OK");
             }
+            output.AppendLine();
+            return false;
         }
+
     }
 }


### PR DESCRIPTION
Create a log of changes to display to user. Allow other menu options to
add to scene or project to use these new changes. Add additional checks
for unchecked/missing holographic options using API (rather than file
processing). Don't reload for quality level changes (Unity picks up
change in file).  Don't set quality if the option is already set
(therefore don't reload when not necessary)