### PR TITLE
Build only enabled scenes when using "Build Visual Studio SLN" button in Build Window

### DIFF
--- a/Assets/HoloToolkit/Build/Editor/BuildDeployTools.cs
+++ b/Assets/HoloToolkit/Build/Editor/BuildDeployTools.cs
@@ -30,7 +30,7 @@ namespace HoloToolkit.Unity
             {
                 // These properties should all match what the Standalone.proj file specifies
                 OutputDirectory = buildDirectory,
-                Scenes = EditorBuildSettings.scenes.Select(scene => scene.path),
+                Scenes = EditorBuildSettings.scenes.Where(scene => scene.enabled).Select(scene => scene.path),
                 BuildTarget = BuildTarget.WSAPlayer,
                 WSASdk = WSASDK.UWP,
                 WSAUWPBuildType = WSAUWPBuildType.D3D,

--- a/Assets/HoloToolkit/Build/Editor/BuildSLNUtilities.cs
+++ b/Assets/HoloToolkit/Build/Editor/BuildSLNUtilities.cs
@@ -283,7 +283,7 @@ namespace HoloToolkit.Unity
             BuildInfo buildInfo = new BuildInfo()
             {
                 // Use scenes from the editor build settings.
-                Scenes = EditorBuildSettings.scenes.Select(scene => scene.path),
+                Scenes = EditorBuildSettings.scenes.Where(scene => scene.enabled).Select(scene => scene.path),
             };
 
             ParseBuildCommandLine(ref buildInfo);


### PR DESCRIPTION
When building an app from unity it's possible to have multiple scenes in
the build window, but only have one scene enabled. Unity only includes the
enabled scenes, see https://docs.unity3d.com/Manual/BuildSettings.html.
Have HoloToolkit build window match this behavior.