### PR TITLE
Prevent DevicePassword from being overwritten

### DIFF
--- a/Assets/HoloToolkit/Build/Editor/BuildDeployPrefs.cs
+++ b/Assets/HoloToolkit/Build/Editor/BuildDeployPrefs.cs
@@ -59,8 +59,8 @@ namespace HoloToolkit.Unity
         }
         public static bool FullReinstall
         {
-            get { return GetEditorPref(EditorPrefs_DevicePwd, true); }
-            set { EditorPrefs.SetBool(EditorPrefs_DevicePwd, value); }
+            get { return GetEditorPref(EditorPrefs_FullReinstall, true); }
+            set { EditorPrefs.SetBool(EditorPrefs_FullReinstall, value); }
         }
 
         private static string GetEditorPref(string key, string defaultValue)


### PR DESCRIPTION
BuildDeployPrefs.FullReinstall was overwriting the BuildDeployPrefs.DevicePassword field every time it gets set, making it impossible to enter a password.