### PR TITLE
Fixed cursors to offset along gaze direction.

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/BasicCursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/BasicCursor.cs
@@ -62,7 +62,7 @@ namespace HoloToolkit.Unity
             meshRenderer.enabled = GazeManager.Instance.Hit;
 
             // Place the cursor at the calculated position.
-            this.gameObject.transform.position = GazeManager.Instance.Position + GazeManager.Instance.Normal * DistanceFromCollision;
+            this.gameObject.transform.position = GazeManager.Instance.Position - Vector3.Normalize(GazeManager.Instance.Position - Camera.main.transform.position) * DistanceFromCollision;
 
             // Reorient the cursor to match the hit object normal.
             this.gameObject.transform.up = GazeManager.Instance.Normal;

--- a/Assets/HoloToolkit/Input/Scripts/CursorManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/CursorManager.cs
@@ -53,7 +53,7 @@ public partial class CursorManager : Singleton<CursorManager>
         }
 
         // Place the cursor at the calculated position.
-        this.gameObject.transform.position = GazeManager.Instance.Position + GazeManager.Instance.Normal * DistanceFromCollision;
+        this.gameObject.transform.position = GazeManager.Instance.Position - Vector3.Normalize(GazeManager.Instance.Position - Camera.main.transform.position) * DistanceFromCollision;
 
         // Orient the cursor to match the surface being gazed at.
         gameObject.transform.up = GazeManager.Instance.Normal;


### PR DESCRIPTION
Modified cursors to apply the DistanceFromCollision offset along the
gaze direction rather than the normal of the hit object. Using this
method the cursor stays in line with gaze even with large
DistanceFromCollision values.

Prior to this change if GazeManager.Normal has a large angle of
incidence with the gaze direction the cursor would not line up with gaze,
the higher DistanceFromCollision the worse it would be.  Try out the
ColorPicker example with and without the change to see the improvement.