### PR TITLE
Build Window - Add option to auto-increment appx version

### DIFF
--- a/Assets/HoloToolkit/Build/Editor/BuildDeployPrefs.cs
+++ b/Assets/HoloToolkit/Build/Editor/BuildDeployPrefs.cs
@@ -16,6 +16,7 @@ namespace HoloToolkit.Unity
         private const string EditorPrefs_BuildDir = "BuildDeployWindow_BuildDir";
         private const string EditorPrefs_BuildConfig = "BuildDeployWindow_BuildConfig";
         private const string EditorPrefs_ForceRebuild = "BuildDeployWindow_ForceBuild";
+        private const string EditorPrefs_IncrementBuildVersion = "BuildDeployWindow_IncrementBuildVersion";
         private const string EditorPrefs_MSBuildVer = "BuildDeployWindow_MSBuildVer";
         private const string EditorPrefs_TargetIPs = "BuildDeployWindow_DestIPs";
         private const string EditorPrefs_DeviceUser = "BuildDeployWindow_DeviceUser";
@@ -45,6 +46,11 @@ namespace HoloToolkit.Unity
         {
             get { return GetEditorPref(EditorPrefs_ForceRebuild, false); }
             set { EditorPrefs.SetBool(EditorPrefs_ForceRebuild, value); }
+        }
+        public static bool IncrementBuildVersion
+        {
+            get { return GetEditorPref(EditorPrefs_IncrementBuildVersion, true); }
+            set { EditorPrefs.SetBool(EditorPrefs_IncrementBuildVersion, value); }
         }
         public static string TargetIPs
         {

--- a/Assets/HoloToolkit/Build/Editor/BuildDeployTools.cs
+++ b/Assets/HoloToolkit/Build/Editor/BuildDeployTools.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
+using System.Xml.Linq;
 
 namespace HoloToolkit.Unity
 {
@@ -70,7 +71,7 @@ namespace HoloToolkit.Unity
             }
         }
 
-        public static bool BuildAppxFromSolution(string productName, string msBuildVersion, bool forceRebuildAppx, string buildConfig, string buildDirectory)
+        public static bool BuildAppxFromSolution(string productName, string msBuildVersion, bool forceRebuildAppx, string buildConfig, string buildDirectory, bool incrementVersion)
         {
             // Get and validate the msBuild path...
             string vs = CalcMSBuildPath(msBuildVersion);
@@ -99,6 +100,13 @@ namespace HoloToolkit.Unity
                 nugetP.StartInfo = nugetPInfo;
                 nugetP.Start();
                 nugetP.WaitForExit();
+            }
+
+            // Ensure that the generated .appx version increments by modifying
+            // Package.appxmanifest
+            if (incrementVersion)
+            {
+                IncrementPackageVersion();
             }
 
             // Now do the actual build
@@ -134,6 +142,48 @@ namespace HoloToolkit.Unity
                 BuildDeployWindow.OpenWindow();
                 return true;
             }
+        }
+
+        private static void IncrementPackageVersion()
+        {
+            // Find the manifest, assume the one we want is the first one
+            string[] manifests = Directory.GetFiles(BuildDeployPrefs.AbsoluteBuildDirectory, "Package.appxmanifest", SearchOption.AllDirectories);
+            if (manifests.Length == 0)
+            {
+                Debug.LogError("Unable to find Package.appxmanifest file for build (in path - " + BuildDeployPrefs.AbsoluteBuildDirectory + ")");
+                return;
+            }
+            string manifest = manifests[0];
+
+            XElement rootNode = XElement.Load(manifest);
+            XNamespace ns = rootNode.GetDefaultNamespace();
+            var identityNode = rootNode.Element(ns + "Identity");
+            if (identityNode == null)
+            {
+                Debug.LogError("Package.appxmanifest for build (in path - " + BuildDeployPrefs.AbsoluteBuildDirectory + ") is missing an <Identity /> node");
+                return;
+            }
+
+            // We use XName.Get instead of strint -> XName implicit conversion because
+            // when we pass in the string "Version", the program doesn't find the attribute.
+            // Best guess as to why this happens is that implicit string conversion doesn't set the namespace to empty
+            var versionAttr = identityNode.Attribute(XName.Get("Version"));
+            if (versionAttr == null)
+            {
+                Debug.LogError("Package.appxmanifest for build (in path - " + BuildDeployPrefs.AbsoluteBuildDirectory + ") is missing a version attribute in the <Identity /> node.");
+                return;
+            }
+
+            // Assume package version always has a '.'.
+            // According to https://msdn.microsoft.com/en-us/library/windows/apps/br211441.aspx
+            // Package versions are always of the form Major.Minor.Build.Revision
+            var curVersionStr = versionAttr.Value;
+            var curVersion = int.Parse(curVersionStr.Split('.').Last());
+            var newVersionStr = curVersionStr.Substring(0, curVersionStr.LastIndexOf('.') + 1) +
+                            (curVersion + 1).ToString();
+
+            versionAttr.Value = newVersionStr;
+            rootNode.Save(manifest);
         }
     }
 }

--- a/Assets/HoloToolkit/Build/Editor/BuildDeployTools.cs
+++ b/Assets/HoloToolkit/Build/Editor/BuildDeployTools.cs
@@ -177,7 +177,6 @@ namespace HoloToolkit.Unity
             // Assume package version always has a '.'.
             // According to https://msdn.microsoft.com/en-us/library/windows/apps/br211441.aspx
             // Package versions are always of the form Major.Minor.Build.Revision
-            var curVersionStr = versionAttr.Value;
             var version = new Version(versionAttr.Value);
             var newVersion = new Version(version.Major, version.Minor, version.Build, version.Revision + 1);
 

--- a/Assets/HoloToolkit/Build/Editor/BuildDeployTools.cs
+++ b/Assets/HoloToolkit/Build/Editor/BuildDeployTools.cs
@@ -164,7 +164,7 @@ namespace HoloToolkit.Unity
                 return;
             }
 
-            // We use XName.Get instead of strint -> XName implicit conversion because
+            // We use XName.Get instead of string -> XName implicit conversion because
             // when we pass in the string "Version", the program doesn't find the attribute.
             // Best guess as to why this happens is that implicit string conversion doesn't set the namespace to empty
             var versionAttr = identityNode.Attribute(XName.Get("Version"));
@@ -178,11 +178,10 @@ namespace HoloToolkit.Unity
             // According to https://msdn.microsoft.com/en-us/library/windows/apps/br211441.aspx
             // Package versions are always of the form Major.Minor.Build.Revision
             var curVersionStr = versionAttr.Value;
-            var curVersion = int.Parse(curVersionStr.Split('.').Last());
-            var newVersionStr = curVersionStr.Substring(0, curVersionStr.LastIndexOf('.') + 1) +
-                            (curVersion + 1).ToString();
+            var version = new Version(versionAttr.Value);
+            var newVersion = new Version(version.Major, version.Minor, version.Build, version.Revision + 1);
 
-            versionAttr.Value = newVersionStr;
+            versionAttr.Value = newVersion.ToString();
             rootNode.Save(manifest);
         }
     }

--- a/Assets/HoloToolkit/Build/Editor/BuildDeployWindow.cs
+++ b/Assets/HoloToolkit/Build/Editor/BuildDeployWindow.cs
@@ -179,8 +179,9 @@ namespace HoloToolkit.Unity
             {
                 GUILayout.FlexibleSpace();
 
+                float previousLabelWidth = EditorGUIUtility.labelWidth;
+
                 // Force rebuild
-                float labelWidth = EditorGUIUtility.labelWidth;
                 EditorGUIUtility.labelWidth = 50;
                 bool curForceRebuildAppx = BuildDeployPrefs.ForceRebuild;
                 bool newForceRebuildAppx = EditorGUILayout.Toggle("Rebuild", curForceRebuildAppx);
@@ -189,13 +190,24 @@ namespace HoloToolkit.Unity
                     BuildDeployPrefs.ForceRebuild = newForceRebuildAppx;
                     curForceRebuildAppx = newForceRebuildAppx;
                 }
-                EditorGUIUtility.labelWidth = labelWidth;
+
+                // Increment version
+                EditorGUIUtility.labelWidth = 110;
+                bool curIncrementVersion = BuildDeployPrefs.IncrementBuildVersion;
+                bool newIncrementVersion = EditorGUILayout.Toggle("Increment version", curIncrementVersion);
+                if (newIncrementVersion != curIncrementVersion) {
+                    BuildDeployPrefs.IncrementBuildVersion = newIncrementVersion;
+                    curIncrementVersion = newIncrementVersion;
+                }
+
+                // Restore previous label width
+                EditorGUIUtility.labelWidth = previousLabelWidth;
 
                 // Build APPX
                 GUI.enabled = ShouldBuildAppxBeEnabled;
                 if (GUILayout.Button("Build APPX from SLN", GUILayout.Width(buttonWidth_Half)))
                 {
-                    BuildDeployTools.BuildAppxFromSolution(appName, curMSBuildVer, curForceRebuildAppx, curBuildConfig, curBuildDirectory);
+                    BuildDeployTools.BuildAppxFromSolution(appName, curMSBuildVer, curForceRebuildAppx, curBuildConfig, curBuildDirectory, curIncrementVersion);
                 }
                 GUI.enabled = true;
             }
@@ -411,7 +423,8 @@ namespace HoloToolkit.Unity
                 BuildDeployPrefs.MsBuildVersion, 
                 BuildDeployPrefs.ForceRebuild, 
                 BuildDeployPrefs.BuildConfig, 
-                BuildDeployPrefs.BuildDirectory))
+                BuildDeployPrefs.BuildDirectory,
+                BuildDeployPrefs.IncrementBuildVersion))
             {
                 return;
             }


### PR DESCRIPTION
- Add checkbox "Increment version" in build window
- If checked, build a new appx, incrementing the last number in
  Major.Minor.Build.Revision. Example: 1.0.0.3 => 1.0.0.4

This can be useful for easily checkpointing your work, especially when
you're actively working on something and somebody asks for a demo it's
easy to just install an older version.