### PR TITLE
Change camera backgorund color

### DIFF
--- a/Assets/HoloToolkit/Utilities/Editor/ConfigureMenu.cs
+++ b/Assets/HoloToolkit/Utilities/Editor/ConfigureMenu.cs
@@ -36,7 +36,7 @@ namespace HoloToolkit.Unity
 
             Camera.main.transform.position = Vector3.zero;
             Camera.main.clearFlags = CameraClearFlags.SolidColor;
-            Camera.main.backgroundColor = Color.black;
+            Camera.main.backgroundColor = Color.clear;
             Camera.main.nearClipPlane = 0.85f;
             Camera.main.fieldOfView = 16.0f;
         }


### PR DESCRIPTION
Camera background color to RGBA 0,0,0,0. But "Apply HoloLens Scene Settings" is black(0,0,0,1)
It was changed from black to clear.

https://developer.microsoft.com/en-us/windows/holographic/unity_development_overview#configuring_a_unity_project_for_hololens