### PR TITLE
bug fix - Update builds before computing most recent build

### DIFF
--- a/Assets/HoloToolkit/Build/Editor/BuildDeployWindow.cs
+++ b/Assets/HoloToolkit/Build/Editor/BuildDeployWindow.cs
@@ -437,6 +437,7 @@ namespace HoloToolkit.Unity
 
         private string CalcMostRecentBuild()
         {
+            UpdateBuilds();
             DateTime mostRecent = DateTime.MinValue;
             string mostRecentBuild = "";
             foreach (var fullBuildLocation in this.builds)


### PR DESCRIPTION
If we press "Build SLN, Build APPX, then Install" and we are incrementing
the appx version on every build, we end up installing the _second to last_
build instead of the _most recent build_ because we are not updating the
list of builds in BuildDeployWindow.CalcMostRecentBuild. Fix this.