### PR TITLE
Adding support for hand based object manipulation

### DIFF
--- a/Assets/HoloToolkit/Input/README.md
+++ b/Assets/HoloToolkit/Input/README.md
@@ -72,10 +72,24 @@ Stabilize the user's gaze to account for head jitter.
 **StabilityVarianceWeight** Stability variance weight multiplier factor.
 
 #### GestureManager.cs
-GestureManager creates a gesture recognizer and signs up for a tap gesture. When a tap gesture is detected, GestureManager uses GazeManager to find the game object.
-GestureManager then sends a message to that game object. 
+GestureManager provides access to several different input gestures, including Tap and Manipulation. 
 
-It also has an **OverrideFocusedObject** which lets you send gesture input to a specific object by overriding the gaze.
+When a tap gesture is detected, GestureManager uses GazeManager to find the game object.
+GestureManager then sends a message to that game object.  It also has an **OverrideFocusedObject** which lets you send gesture input to a specific object by overriding the gaze.
+
+Using Manipulation requires subscribing to the ManipulationStarted events and then querying information about the manipulation gesture via ManipulationOffset and ManipulationHandPosition.  See GestureManipulator for an example.
+
+#### GestureManipulator.cs
+A component for moving an object via the GestureManager manipulation gesture.
+
+When an active GestureManipulator component is attached to a GameObject it will subscribe 
+to GestureManager's manipulation gestures, and move the GameObject when a ManipulationGesture occurs. 
+If the GestureManipulator is disabled it will not respond to any manipulation gestures. 
+ 
+This means that if multiple GestureManipulators are active in a given scene when a manipulation 
+gesture is performed, all the relevant GameObjects will be moved.  If the desired behavior is that only 
+a single object be moved at a time, it is recommended that objects which should not be moved disable 
+their GestureManipulators, then re-enable them when necessary (e.g. the object is focused). 
 
 #### HandGuidance.cs
 Show a GameObject when a gesturing hand is about to lose tracking.

--- a/Assets/HoloToolkit/Input/Scripts/GestureManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/GestureManager.cs
@@ -3,17 +3,40 @@
 
 using UnityEngine;
 using UnityEngine.VR.WSA.Input;
+using System.Collections.Generic;
 
 namespace HoloToolkit.Unity
 {
     /// <summary>
-    /// GestureManager creates a gesture recognizer and signs up for a tap gesture.
+    /// GestureManager provides access to several different input gestures, including
+    /// Tap and Manipulation.
+    /// </summary>
+    /// <remarks>
     /// When a tap gesture is detected, GestureManager uses GazeManager to find the game object.
     /// GestureManager then sends a message to that game object.
-    /// </summary>
+    /// 
+    /// Using Manipulation requires subscribing the the ManipulationStarted events and then querying
+    /// information about the manipulation gesture via ManipulationOffset and ManipulationHandPosition
+    /// </remarks>
     [RequireComponent(typeof(GazeManager))]
     public partial class GestureManager : Singleton<GestureManager>
     {
+        /// <summary>
+        /// Occurs when a manipulation gesture has started
+        /// </summary>
+        public System.Action ManipulationStarted;
+
+        /// <summary>
+        /// Occurs when a manipulation gesture ended as a result of user input
+        /// </summary>
+        public System.Action ManipulationCompleted;
+
+        /// <summary>
+        /// Occurs when a manipulated gesture ended as a result of some other condition.
+        /// (e.g. the hand being used for the gesture is no longer visible).
+        /// </summary>
+        public System.Action ManipulationCanceled;
+
         /// <summary>
         /// Key to press in the editor to select the currently gazed hologram
         /// </summary>
@@ -24,40 +47,104 @@ namespace HoloToolkit.Unity
         /// set the override focused object.
         /// If its null, then the gazed at object will be selected.
         /// </summary>
-        public GameObject OverrideFocusedObject
-        {
-            get; set;
-        }
-
+        public GameObject OverrideFocusedObject { get; set; }
+        
         /// <summary>
         /// Gets the currently focused object, or null if none.
         /// </summary>
-        public GameObject FocusedObject
+        public GameObject FocusedObject { get; private set; }
+
+        /// <summary>
+        /// Whether or not a manipulation gesture is currently in progress
+        /// </summary>
+        public bool ManipulationInProgress { get; private set; }
+
+        /// <summary>
+        /// The offset of the hand from its position at the beginning of 
+        /// the currently active manipulation gesture, in world space.  Not valid if
+        /// a manipulation gesture is not in progress
+        /// </summary>
+        public Vector3 ManipulationOffset { get; private set; }
+
+        /// <summary>
+        /// The world space position of the hand being used for the current manipulation gesture.  Not valid
+        /// if a manipulation gesture is not in progress.
+        /// </summary>
+        public Vector3 ManipulationHandPosition
         {
-            get { return focusedObject; }
+            get
+            {
+                Vector3 handPosition = Vector3.zero;
+                currentHandState.properties.location.TryGetPosition(out handPosition);
+                return handPosition;
+            }
         }
 
         private GestureRecognizer gestureRecognizer;
-        private GameObject focusedObject;
+        // We use a separate manipulation recognizer here because the tap gesture recognizer cancels
+        // capturing gestures whenever the GazeManager focus changes, which is not the behavior
+        // we want for manipulation
+        private GestureRecognizer manipulationRecognizer;
+
+        private bool HandPressed { get { return pressedHands.Count > 0; } }
+        private HashSet<uint> pressedHands = new HashSet<uint>();
+
+        private InteractionSourceState currentHandState;
 
         void Start()
         {
+            InteractionManager.SourcePressed += InteractionManager_SourcePressed;
+            InteractionManager.SourceReleased += InteractionManager_SourceReleased;
+            InteractionManager.SourceUpdated += InteractionManager_SourceUpdated;
+            InteractionManager.SourceLost += InteractionManager_SourceLost;
+
             // Create a new GestureRecognizer. Sign up for tapped events.
             gestureRecognizer = new GestureRecognizer();
             gestureRecognizer.SetRecognizableGestures(GestureSettings.Tap);
 
+            manipulationRecognizer = new GestureRecognizer();
+            manipulationRecognizer.SetRecognizableGestures(GestureSettings.ManipulationTranslate);
+
             gestureRecognizer.TappedEvent += GestureRecognizer_TappedEvent;
+
+            manipulationRecognizer.ManipulationStartedEvent += ManipulationRecognizer_ManipulationStartedEvent;
+            manipulationRecognizer.ManipulationUpdatedEvent += ManipulationRecognizer_ManipulationUpdatedEvent;
+            manipulationRecognizer.ManipulationCompletedEvent += ManipulationRecognizer_ManipulationCompletedEvent;
+            manipulationRecognizer.ManipulationCanceledEvent += ManipulationRecognizer_ManipulationCanceledEvent;
 
             // Start looking for gestures.
             gestureRecognizer.StartCapturingGestures();
+            manipulationRecognizer.StartCapturingGestures();
         }
 
-        private void OnTap()
+
+
+        private void InteractionManager_SourcePressed(InteractionSourceState state)
         {
-            if (focusedObject != null)
+            if (!HandPressed)
             {
-                focusedObject.SendMessage("OnSelect");
+                currentHandState = state;
             }
+
+            pressedHands.Add(state.source.id);
+        }
+
+        private void InteractionManager_SourceUpdated(InteractionSourceState state)
+        {
+            if (HandPressed && state.source.id == currentHandState.source.id)
+            {
+                currentHandState = state;
+            }
+        }
+
+        private void InteractionManager_SourceReleased(InteractionSourceState state)
+        {
+            pressedHands.Remove(state.source.id);
+        }
+
+        private void InteractionManager_SourceLost(InteractionSourceState state)
+        {
+            pressedHands.Remove(state.source.id);
         }
 
         private void GestureRecognizer_TappedEvent(InteractionSourceKind source, int tapCount, Ray headRay)
@@ -65,9 +152,59 @@ namespace HoloToolkit.Unity
             OnTap();
         }
 
+        private void OnTap()
+        {
+            if (FocusedObject != null)
+            {
+                FocusedObject.SendMessage("OnSelect");
+            }
+        }
+
+        private void ManipulationRecognizer_ManipulationStartedEvent(InteractionSourceKind source, Vector3 cumulativeDelta, Ray headRay)
+        {
+            // Don't start another manipulation gesture if one is already underway
+            if (!ManipulationInProgress)
+            {
+                OnManipulation(true, cumulativeDelta);
+                if (ManipulationStarted != null)
+                {
+                    ManipulationStarted();
+                }
+            }
+        }
+
+        private void ManipulationRecognizer_ManipulationUpdatedEvent(InteractionSourceKind source, Vector3 cumulativeDelta, Ray headRay)
+        {
+            OnManipulation(true, cumulativeDelta);
+        }
+
+        private void ManipulationRecognizer_ManipulationCompletedEvent(InteractionSourceKind source, Vector3 cumulativeDelta, Ray headRay)
+        {
+            OnManipulation(false, cumulativeDelta);
+            if (ManipulationCompleted != null)
+            {
+                ManipulationCompleted();
+            }
+        }
+
+        private void ManipulationRecognizer_ManipulationCanceledEvent(InteractionSourceKind source, Vector3 cumulativeDelta, Ray headRay)
+        {
+            OnManipulation(false, cumulativeDelta);
+            if (ManipulationCanceled != null)
+            {
+                ManipulationCanceled();
+            }
+        }
+
+        private void OnManipulation(bool inProgress, Vector3 offset)
+        {
+            ManipulationInProgress = inProgress;
+            ManipulationOffset = offset;
+        }
+
         void LateUpdate()
         {
-            GameObject oldFocusedObject = focusedObject;
+            GameObject oldFocusedObject = FocusedObject;
 
             if (GazeManager.Instance.Hit &&
                 OverrideFocusedObject == null &&
@@ -75,15 +212,15 @@ namespace HoloToolkit.Unity
             {
                 // If gaze hits a hologram, set the focused object to that game object.
                 // Also if the caller has not decided to override the focused object.
-                focusedObject = GazeManager.Instance.HitInfo.collider.gameObject;
+                FocusedObject = GazeManager.Instance.HitInfo.collider.gameObject;
             }
             else
             {
                 // If our gaze doesn't hit a hologram, set the focused object to null or override focused object.
-                focusedObject = OverrideFocusedObject;
+                FocusedObject = OverrideFocusedObject;
             }
 
-            if (focusedObject != oldFocusedObject)
+            if (FocusedObject != oldFocusedObject)
             {
                 // If the currently focused object doesn't match the old focused object, cancel the current gesture.
                 // Start looking for new gestures.  This is to prevent applying gestures from one hologram to another.
@@ -103,6 +240,17 @@ namespace HoloToolkit.Unity
         {
             gestureRecognizer.StopCapturingGestures();
             gestureRecognizer.TappedEvent -= GestureRecognizer_TappedEvent;
+
+            manipulationRecognizer.StopCapturingGestures();
+            manipulationRecognizer.ManipulationStartedEvent -= ManipulationRecognizer_ManipulationStartedEvent;
+            manipulationRecognizer.ManipulationUpdatedEvent -= ManipulationRecognizer_ManipulationUpdatedEvent;
+            manipulationRecognizer.ManipulationCompletedEvent -= ManipulationRecognizer_ManipulationCompletedEvent;
+            manipulationRecognizer.ManipulationCanceledEvent -= ManipulationRecognizer_ManipulationCanceledEvent;
+
+            InteractionManager.SourcePressed -= InteractionManager_SourcePressed;
+            InteractionManager.SourceReleased -= InteractionManager_SourceReleased;
+            InteractionManager.SourceUpdated -= InteractionManager_SourceUpdated;
+            InteractionManager.SourceLost -= InteractionManager_SourceLost;
         }
     }
 }

--- a/Assets/HoloToolkit/Input/Scripts/GestureManipulator.cs
+++ b/Assets/HoloToolkit/Input/Scripts/GestureManipulator.cs
@@ -1,0 +1,117 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using HoloToolkit.Unity;
+using UnityEngine;
+
+namespace HoloToolkit.Unity
+{
+    /// <summary>
+    /// A component for moving an object via the GestureManager manipulation gesture.
+    /// </summary>
+    /// <remarks>
+    /// When an active GestureManipulator component is attached to a GameObject it will subscribe
+    /// to GestureManager's manipulation gestures, and move the GameObject when a ManipulationGesture occurs.
+    /// If the GestureManipulator is disabled it will not respond to any manipulation gestures.
+    /// 
+    /// This means that if multiple GestureManipulators are active in a given scene when a manipulation
+    /// gesture is performed, all the relevant GameObjects will be moved.  If the desired behavior is that only
+    /// a single object be moved at a time, it is recommended that objects which should not be moved disable
+    /// their GestureManipulators, then re-enable them when necessary (e.g. the object is focused).
+    /// </remarks>
+    public class GestureManipulator : MonoBehaviour
+    {
+        [Tooltip("How much to scale each axis of hand movement (camera relative) when manipulating the object")]
+        public Vector3 handPositionScale = new Vector3(2.0f, 2.0f, 4.0f);  // Default tuning values, expected to be modified per application
+
+        private Vector3 initialHandPosition;
+        private Vector3 initialObjectPosition;
+
+        private Interpolator targetInterpolator;
+
+        private bool Manipulating { get; set; }
+
+        private void OnEnable()
+        {
+            if (GestureManager.Instance != null)
+            {
+                GestureManager.Instance.ManipulationStarted += BeginManipulation;
+                GestureManager.Instance.ManipulationCompleted += EndManipulation;
+                GestureManager.Instance.ManipulationCanceled += EndManipulation;
+            }
+            else
+            {
+                Debug.LogError(string.Format("GestureManipulator enabled on {0} could not find GestureManager instance, manipulation will not function", name));
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (GestureManager.Instance)
+            {
+                GestureManager.Instance.ManipulationStarted -= BeginManipulation;
+                GestureManager.Instance.ManipulationCompleted -= EndManipulation;
+                GestureManager.Instance.ManipulationCanceled -= EndManipulation;
+            }
+
+            Manipulating = false;
+        }
+
+        private void BeginManipulation()
+        {
+            if (GestureManager.Instance != null && GestureManager.Instance.ManipulationInProgress)
+            {
+                Manipulating = true;
+
+                targetInterpolator = gameObject.GetComponent<Interpolator>();
+
+                // In order to ensure that any manipulated objects move with the user, we do all our math relative to the camera,
+                // so when we save the initial hand position and object position we first transform them into the camera's coordinate space
+                initialHandPosition = Camera.main.transform.InverseTransformPoint(GestureManager.Instance.ManipulationHandPosition);
+                initialObjectPosition = Camera.main.transform.InverseTransformPoint(transform.position);
+            }
+        }
+
+        private void EndManipulation()
+        {
+            Manipulating = false;
+        }
+
+
+        // Update is called once per frame
+        void Update()
+        {
+            if (Manipulating)
+            {
+                // First step is to figure out the delta between the initial hand position and the current hand position
+                Vector3 localHandPosition = Camera.main.transform.InverseTransformPoint(GestureManager.Instance.ManipulationHandPosition);
+                Vector3 initialHandToCurrentHand = localHandPosition - initialHandPosition;
+
+                // When performing a manipulation gesture, the hand generally only translates a relatively small amount.
+                // If we move the object only as much as the hand itself moves, users can only make small adjustments before
+                // the hand is lost and the gesture completes.  To improve the usability of the gesture we scale each
+                // axis of hand movement by some amount (camera relative).  This value can be changed in the editor or
+                // at runtime based on the needs of individual movement scenarios.
+                Vector3 scaledLocalHandPositionDelta = Vector3.Scale(initialHandToCurrentHand, handPositionScale);
+
+                // Once we've figured out how much the object should move relative to the camera we apply that to the initial
+                // camera relative position.  This ensures that the object remains in the appropriate location relative to the camera
+                // and the hand as the camera moves.  The allows users to use both gaze and gesture to move objects.  Once they
+                // begin manipulating an object they can rotate their head or walk around and the object will move with them
+                // as long as they maintain the gesture, while still allowing adjustment via hand movement.
+                Vector3 localObjectPosition = initialObjectPosition + scaledLocalHandPositionDelta;
+                Vector3 worldObjectPosition = Camera.main.transform.TransformPoint(localObjectPosition);
+
+                // If the object has an interpolator we should use it, otherwise just move the transform directly
+                if (targetInterpolator != null)
+                {
+                    targetInterpolator.SetTargetPosition(worldObjectPosition);
+                }
+                else
+                {
+                    transform.position = worldObjectPosition;
+                }
+            }
+        }
+    }
+}

--- a/Assets/HoloToolkit/Input/Scripts/GestureManipulator.cs.meta
+++ b/Assets/HoloToolkit/Input/Scripts/GestureManipulator.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: e51d7e4929564f445a05c6fd8d51b5c2
+timeCreated: 1472511059
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit/Input/Tests/GestureManipulator.unity
+++ b/Assets/HoloToolkit/Input/Tests/GestureManipulator.unity
@@ -1,0 +1,486 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+SceneSettings:
+  m_ObjectHideFlags: 0
+  m_PVSData: 
+  m_PVSObjectsArray: []
+  m_PVSPortalsArray: []
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 7
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 7
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_TemporalCoherenceThreshold: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 1
+  m_LightmapEditorSettings:
+    serializedVersion: 4
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_TextureWidth: 1024
+    m_TextureHeight: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_DirectLightInLightProbes: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+  m_LightingDataAsset: {fileID: 0}
+  m_RuntimeCPUUsage: 25
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    accuratePlacement: 0
+    minRegionArea: 2
+    cellSize: 0.16666667
+    manualCellSize: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &218606838
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 218606842}
+  - 33: {fileID: 218606841}
+  - 135: {fileID: 218606840}
+  - 23: {fileID: 218606839}
+  - 114: {fileID: 218606843}
+  - 114: {fileID: 218606844}
+  m_Layer: 0
+  m_Name: Sphere
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!23 &218606839
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 218606838}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_SubsetIndices: 
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedWireframeHidden: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+--- !u!135 &218606840
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 218606838}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &218606841
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 218606838}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &218606842
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 218606838}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 2}
+  m_LocalScale: {x: 0.3, y: 0.3, z: 0.3}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+--- !u!114 &218606843
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 218606838}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e51d7e4929564f445a05c6fd8d51b5c2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  handPositionScale: {x: 2, y: 2, z: 5}
+--- !u!114 &218606844
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 218606838}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fb69de839bd015f4099b5bd2c45e53e5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  PositionPerSecond: 30
+  RotationDegreesPerSecond: 720
+  RotationSpeedScaler: 0
+  ScalePerSecond: 5
+  SmoothLerpToTarget: 0
+  SmoothPositionLerpRatio: 0.5
+  SmoothRotationLerpRatio: 0.5
+  SmoothScaleLerpRatio: 0.5
+--- !u!1 &304231337
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 304231339}
+  - 114: {fileID: 304231340}
+  - 114: {fileID: 304231338}
+  - 114: {fileID: 304231341}
+  m_Layer: 0
+  m_Name: Managers
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &304231338
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 304231337}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cef26a362f41c5248aca879be2a5f04b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &304231339
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 304231337}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+--- !u!114 &304231340
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 304231337}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4d1a2a33ffcac354298137001635a001, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  MaxGazeDistance: 5
+  RaycastLayerMask:
+    serializedVersion: 2
+    m_Bits: 4294967291
+  SetStabilizationPlane: 1
+  LerpStabilizationPlanePowerCloser: 4
+  LerpStabilizationPlanePowerFarther: 7
+--- !u!114 &304231341
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 304231337}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 94c1fd2ccb6e3e5449429462b44a8229, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  EditorSelectKey: 32
+--- !u!1001 &347253923
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4000013243965410, guid: 90749889d87976143a9e21072d2434b4, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000013243965410, guid: 90749889d87976143a9e21072d2434b4, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000013243965410, guid: 90749889d87976143a9e21072d2434b4, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000013243965410, guid: 90749889d87976143a9e21072d2434b4, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0.7069895
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000013243965410, guid: 90749889d87976143a9e21072d2434b4, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000013243965410, guid: 90749889d87976143a9e21072d2434b4, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000013243965410, guid: 90749889d87976143a9e21072d2434b4, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 0.707224
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000013243965410, guid: 90749889d87976143a9e21072d2434b4, type: 2}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 90749889d87976143a9e21072d2434b4, type: 2}
+  m_IsPrefabParent: 0
+--- !u!1 &365083053
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 365083055}
+  - 108: {fileID: 365083054}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &365083054
+Light:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 365083053}
+  m_Enabled: 1
+  serializedVersion: 7
+  m_Type: 1
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_Lightmapping: 4
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &365083055
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 365083053}
+  m_LocalRotation: {x: 0.38268343, y: 0, z: 0, w: 0.92387956}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 45, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+--- !u!1001 &390171155
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 402774, guid: b84b73491ac53a34095000876132a211, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 402774, guid: b84b73491ac53a34095000876132a211, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 402774, guid: b84b73491ac53a34095000876132a211, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 402774, guid: b84b73491ac53a34095000876132a211, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 402774, guid: b84b73491ac53a34095000876132a211, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 402774, guid: b84b73491ac53a34095000876132a211, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 402774, guid: b84b73491ac53a34095000876132a211, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 402774, guid: b84b73491ac53a34095000876132a211, type: 2}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: b84b73491ac53a34095000876132a211, type: 2}
+  m_IsPrefabParent: 0
+--- !u!1 &1239219067
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 1239219069}
+  - 108: {fileID: 1239219068}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1239219068
+Light:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1239219067}
+  m_Enabled: 1
+  serializedVersion: 7
+  m_Type: 1
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_Lightmapping: 4
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1239219069
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1239219067}
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1

--- a/Assets/HoloToolkit/Input/Tests/GestureManipulator.unity.meta
+++ b/Assets/HoloToolkit/Input/Tests/GestureManipulator.unity.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ee65da250ff41eb47913102e42e21cc0
+timeCreated: 1455735875
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Holograms 211 contains a relatively simple implementation of hand based
object manipulation.  That implementation uses the world space deltas
to move holograms exactly as the hand moves.  This works fine in some
cases, but becomes limiting in more sophisticated manipulation
scenarios.

The implementation in this change is taken directly from 3D Viewer
and ActionGrams and supports more sophisticated movement scenarios
which combine both gesture and gaze.  For example, with this new
implementation if you manipulate a hologram and then turn your head
the hologram will move with your head, while still allowing you to make
adjustments with your hands.  If you manipulate a hologram and then
walk somewhere else the hologram will move with you as long as you
maintain the gesture.  This allows for users to make large adjustments
using their gaze and position, while making smaller adjustments with
their hands, resulting in more intuitive and effective manipulation.