### PR TITLE
Added menu item to enable recommended capabilities

### DIFF
--- a/Assets/HoloToolkit/Utilities/Editor/ConfigureMenu.cs
+++ b/Assets/HoloToolkit/Utilities/Editor/ConfigureMenu.cs
@@ -191,52 +191,62 @@ namespace HoloToolkit.Unity
             }
         }
 
-        [MenuItem("HoloToolkit/Configure/HoloLens Recommended Capabilities ", priority = 1)]
-        static void HoloLensRecommendedCapabilities()
+        [MenuItem("HoloToolkit/Configure/Apply HoloLens Capability Settings", priority = 1)]
+        static void ApplyHoloLensCapabilitySettings()
         {
-            AutoConfigureMenu window = (AutoConfigureMenu)EditorWindow.GetWindow(typeof(AutoConfigureMenu), true, "HoloLens Recommended Capabilities");
+            AutoConfigureMenu window = (AutoConfigureMenu)EditorWindow.GetWindow(typeof(AutoConfigureMenu), true, "Apply HoloLens Capability Settings");
             window.Show();
         }
 
         void OnGUI()
         {
-            capability(PlayerSettings.WSACapability.Microphone, @"  Microphone
-Required for access to the HoloLens microphone. 
+            capabilityToggle(PlayerSettings.WSACapability.Microphone, @"Microphone
+
+Required for access to the HoloLens microphone.
 This includes behaviors like DictationRecognizer,
-GrammarRecognizer, and KeywordRecognizer. 
-This capability is NOT required for the 'Select' 
-keyword.Recommendation: Only enable if your 
-application needs access to the microphone 
-beyond the 'Select' keyword.The microphone is 
-considered a privacy sensitive resource.");
+GrammarRecognizer, and KeywordRecognizer.
+This capability is NOT required for the 'Select' keyword.
 
-            capability(PlayerSettings.WSACapability.SpatialPerception, @"   SpatialPerception
+Recommendation: Only enable if your application 
+needs access to the microphone beyond the
+'Select' keyword. The microphone is considered a 
+privacy sensitive resource.");
+
+            capabilityToggle(PlayerSettings.WSACapability.SpatialPerception, @"SpatialPerception
+
 Required for access to the HoloLens world mapping
-capabilities. These include behaviors like 
+capabilities. These include behaviors like
 SurfaceObserver, SpatialMappingManager and 
-SpatialAnchor. Recommendation: Enabled unless 
-your application doesn't use spatial mapping or 
-spatial collisions in any way.");
+SpatialAnchor. 
 
-            capability(PlayerSettings.WSACapability.WebCam, @"  WebCam
+Recommendation: Enabled, unless your application
+doesn't use spatial mapping or spatial collisions
+in any way. ");
+
+            capabilityToggle(PlayerSettings.WSACapability.WebCam, @"WebCam
+
 Required for access to the HoloLens RGB camera 
 (also known as the locatable camera). This 
 includes APIs like PhotoCapture and VideoCapture.
-This capability is NOT required for mixed reality
-streaming or for capture photos or videos from the
-start menu. Recommendation: Only enable if your 
-application needs access to capture raw photos or 
-videos from the RGB camera. The RGB camera is 
+This capability is NOT required for mixed reality 
+streaming or for capturing photos or videos using
+the start menu. 
+
+Recommendation: Only enable if your application 
+needs to programmatically capture photos or 
+videos from the RGB camera. The RGB camera is
 considered a privacy sensitive resource.");
 
-            capability(PlayerSettings.WSACapability.InternetClient, @"  InternetClient
-Required if your application needs to access the 
-Internet. Recommendation: Leave unchecked
-unless your application needs to access online
-services.");
+            capabilityToggle(PlayerSettings.WSACapability.InternetClient, @"Internet Client
+
+Required if your application needs to access 
+the Internet. 
+
+Recommendation: Leave unchecked unless your 
+application uses online services.");
         }
 
-        void capability(PlayerSettings.WSACapability mCap,string tooltip)
+        void capabilityToggle(PlayerSettings.WSACapability mCap,string tooltip)
         {
             PlayerSettings.WSA.SetCapability(mCap, GUILayout.Toggle(PlayerSettings.WSA.GetCapability(mCap), new GUIContent(" " + mCap.ToString(), tooltip)));
         }

--- a/Assets/HoloToolkit/Utilities/Editor/ConfigureMenu.cs
+++ b/Assets/HoloToolkit/Utilities/Editor/ConfigureMenu.cs
@@ -198,13 +198,13 @@ namespace HoloToolkit.Unity
         }
 
         [MenuItem("HoloToolkit/Configure/Apply HoloLens Capabilities/Recommended", priority = 1)]
-        private static void ApplyRecomenndedCapabilities()
+        private static void ApplyRecommendedCapabilities()
         {
             ApplyCommonCapabilities();
         }
 
-        [MenuItem("HoloToolkit/Configure/Apply HoloLens Capabilities/Recommended with Internet", priority = 1)]
-        private static void ApplyRecomenndedCapabilitiesWithInternet()
+        [MenuItem("HoloToolkit/Configure/Apply HoloLens Capabilities/Recommended with Internet Access", priority = 1)]
+        private static void ApplyRecommendedCapabilitiesWithInternetAccess()
         {
             ApplyCommonCapabilities();
             PlayerSettings.WSA.SetCapability(PlayerSettings.WSACapability.InternetClient, true);

--- a/Assets/HoloToolkit/Utilities/Editor/ConfigureMenu.cs
+++ b/Assets/HoloToolkit/Utilities/Editor/ConfigureMenu.cs
@@ -14,9 +14,11 @@ namespace HoloToolkit.Unity
     /// Configuration options derived from here: 
     /// https://developer.microsoft.com/en-us/windows/holographic/unity_development_overview#Configuring_a_Unity_project_for_HoloLens
     /// </summary>
+   
     public static class AutoConfigureMenu
     {
-        [MenuItem("HoloToolkit/Configure/Show Help", priority = 1)]
+       
+        [MenuItem("HoloToolkit/Configure/Show Help", priority = 2)]
         public static void ShowHelp()
         {
             Application.OpenURL("https://developer.microsoft.com/en-us/windows/holographic/unity_development_overview#Configuring_a_Unity_project_for_HoloLens");
@@ -186,6 +188,26 @@ namespace HoloToolkit.Unity
             {
                 Debug.LogException(e);
             }
+        }
+
+        private static void ApplyCommonCapabilities()
+        {
+            PlayerSettings.WSA.SetCapability(PlayerSettings.WSACapability.Microphone, true);
+            PlayerSettings.WSA.SetCapability(PlayerSettings.WSACapability.SpatialPerception, true);
+            PlayerSettings.WSA.SetCapability(PlayerSettings.WSACapability.WebCam, true);
+        }
+
+        [MenuItem("HoloToolkit/Configure/Apply HoloLens Capabilities/Recommended", priority = 1)]
+        private static void ApplyRecomenndedCapabilities()
+        {
+            ApplyCommonCapabilities();
+        }
+
+        [MenuItem("HoloToolkit/Configure/Apply HoloLens Capabilities/Recommended with Internet", priority = 1)]
+        private static void ApplyRecomenndedCapabilitiesWithInternet()
+        {
+            ApplyCommonCapabilities();
+            PlayerSettings.WSA.SetCapability(PlayerSettings.WSACapability.InternetClient, true);
         }
     }
 }

--- a/Assets/HoloToolkit/Utilities/Editor/ConfigureMenu.cs
+++ b/Assets/HoloToolkit/Utilities/Editor/ConfigureMenu.cs
@@ -14,10 +14,11 @@ namespace HoloToolkit.Unity
     /// Configuration options derived from here: 
     /// https://developer.microsoft.com/en-us/windows/holographic/unity_development_overview#Configuring_a_Unity_project_for_HoloLens
     /// </summary>
-   
-    public static class AutoConfigureMenu
+
+    
+    public class AutoConfigureMenu : UnityEditor.EditorWindow
     {
-       
+
         [MenuItem("HoloToolkit/Configure/Show Help", priority = 2)]
         public static void ShowHelp()
         {
@@ -190,24 +191,56 @@ namespace HoloToolkit.Unity
             }
         }
 
-        private static void ApplyCommonCapabilities()
+        [MenuItem("HoloToolkit/Configure/HoloLens Recommended Capabilities ", priority = 1)]
+        static void HoloLensRecommendedCapabilities()
         {
-            PlayerSettings.WSA.SetCapability(PlayerSettings.WSACapability.Microphone, true);
-            PlayerSettings.WSA.SetCapability(PlayerSettings.WSACapability.SpatialPerception, true);
-            PlayerSettings.WSA.SetCapability(PlayerSettings.WSACapability.WebCam, true);
+            AutoConfigureMenu window = (AutoConfigureMenu)EditorWindow.GetWindow(typeof(AutoConfigureMenu), true, "HoloLens Recommended Capabilities");
+            window.Show();
         }
 
-        [MenuItem("HoloToolkit/Configure/Apply HoloLens Capabilities/Recommended", priority = 1)]
-        private static void ApplyRecommendedCapabilities()
+        void OnGUI()
         {
-            ApplyCommonCapabilities();
+            capability(PlayerSettings.WSACapability.Microphone, @"  Microphone
+Required for access to the HoloLens microphone. 
+This includes behaviors like DictationRecognizer,
+GrammarRecognizer, and KeywordRecognizer. 
+This capability is NOT required for the 'Select' 
+keyword.Recommendation: Only enable if your 
+application needs access to the microphone 
+beyond the 'Select' keyword.The microphone is 
+considered a privacy sensitive resource.");
+
+            capability(PlayerSettings.WSACapability.SpatialPerception, @"   SpatialPerception
+Required for access to the HoloLens world mapping
+capabilities. These include behaviors like 
+SurfaceObserver, SpatialMappingManager and 
+SpatialAnchor. Recommendation: Enabled unless 
+your application doesn't use spatial mapping or 
+spatial collisions in any way.");
+
+            capability(PlayerSettings.WSACapability.WebCam, @"  WebCam
+Required for access to the HoloLens RGB camera 
+(also known as the locatable camera). This 
+includes APIs like PhotoCapture and VideoCapture.
+This capability is NOT required for mixed reality
+streaming or for capture photos or videos from the
+start menu. Recommendation: Only enable if your 
+application needs access to capture raw photos or 
+videos from the RGB camera. The RGB camera is 
+considered a privacy sensitive resource.");
+
+            capability(PlayerSettings.WSACapability.InternetClient, @"  InternetClient
+Required if your application needs to access the 
+Internet. Recommendation: Leave unchecked
+unless your application needs to access online
+services.");
         }
 
-        [MenuItem("HoloToolkit/Configure/Apply HoloLens Capabilities/Recommended with Internet Access", priority = 1)]
-        private static void ApplyRecommendedCapabilitiesWithInternetAccess()
+        void capability(PlayerSettings.WSACapability mCap,string tooltip)
         {
-            ApplyCommonCapabilities();
-            PlayerSettings.WSA.SetCapability(PlayerSettings.WSACapability.InternetClient, true);
+            PlayerSettings.WSA.SetCapability(mCap, GUILayout.Toggle(PlayerSettings.WSA.GetCapability(mCap), new GUIContent(" " + mCap.ToString(), tooltip)));
         }
+
+
     }
 }


### PR DESCRIPTION
This pull request addresses #202. It adds a new menu item underneath the HoloToolkit to enable the recommended default capabilities. There are two options:

1. Recommended
2. Recommended with Internet

Both options enable Microphone, SpatialPerception and WebCam. The second option also enables InternetClient.