### PR TITLE
Added voice selection to TextToSpeechManager.

### DIFF
--- a/Assets/HoloToolkit/Utilities/Scripts/TextToSpeechManager.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/TextToSpeechManager.cs
@@ -54,10 +54,12 @@ namespace HoloToolkit.Unity
     {
         // Inspector Variables
         [Tooltip("The audio source where speech will be played.")]
-        public AudioSource audioSource;
+        [SerializeField]
+        private AudioSource audioSource;
 
         [Tooltip("The voice that will be used to generate speech.")]
-        public TextToSpeechVoice voice;
+        [SerializeField]
+        private TextToSpeechVoice voice;
 
         // Member Variables
         #if WINDOWS_UWP
@@ -379,5 +381,15 @@ namespace HoloToolkit.Unity
             LogSpeech(text);
             #endif
         }
+
+        /// <summary>
+        /// Gets or sets the audio source where speech will be played.
+        /// </summary>
+        public AudioSource AudioSource { get { return audioSource; } set { audioSource = value; } }
+
+        /// <summary>
+        /// Gets or sets the voice that will be used to generate speech.
+        /// </summary>
+        public TextToSpeechVoice Voice { get { return voice; } set { voice = value; } }
     }
 }

--- a/Assets/HoloToolkit/Utilities/Tests/TextToSpeechManager.unity
+++ b/Assets/HoloToolkit/Utilities/Tests/TextToSpeechManager.unity
@@ -122,6 +122,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   audioSource: {fileID: 26734026}
+  voice: 1
 --- !u!82 &26734026
 AudioSource:
   m_ObjectHideFlags: 0
@@ -209,7 +210,7 @@ MeshRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_Materials:
-  - {fileID: 2100000, guid: a97cfdf0ccbea464aa0da62aa7eed38b, type: 2}
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
   m_SubsetIndices: 
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
@@ -253,10 +254,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -1.2, y: 0, z: -1.2}
   m_LocalScale: {x: 0.2, y: 0.2, z: 0.2}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &229025307
 GameObject:
   m_ObjectHideFlags: 0
@@ -283,11 +284,11 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 488360707}
   m_Father: {fileID: 1871194243}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
@@ -351,10 +352,10 @@ Transform:
   m_LocalRotation: {x: -0.15622348, y: -0.82451075, z: 0.46962523, w: -0.27427816}
   m_LocalPosition: {x: 0, y: 2, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 59.33, y: -216.8, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 59.33, y: -216.8, z: 0}
 --- !u!108 &250906385
 Light:
   m_ObjectHideFlags: 0
@@ -372,6 +373,7 @@ Light:
   m_Shadows:
     m_Type: 0
     m_Resolution: -1
+    m_CustomResolution: -1
     m_Strength: 1
     m_Bias: 0.05
     m_NormalBias: 0.4
@@ -388,54 +390,6 @@ Light:
   m_BounceIntensity: 1
   m_ShadowRadius: 0
   m_ShadowAngle: 0
---- !u!1 &478672352
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1000012943254746, guid: b2db04283121ca74495c2ee000fb4243,
-    type: 2}
-  m_PrefabInternal: {fileID: 1484279150}
-  serializedVersion: 4
-  m_Component:
-  - 4: {fileID: 478672354}
-  - 114: {fileID: 478672353}
-  m_Layer: 2
-  m_Name: Cursor
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &478672353
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 114000014146313642, guid: b2db04283121ca74495c2ee000fb4243,
-    type: 2}
-  m_PrefabInternal: {fileID: 1484279150}
-  m_GameObject: {fileID: 478672352}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 37be0deba90cea9489f9a6e0acdc84df, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  CursorOnHolograms: {fileID: 734504339}
-  CursorOffHolograms: {fileID: 492701916}
-  DistanceFromCollision: 0.01
---- !u!4 &478672354
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 4000013535415816, guid: b2db04283121ca74495c2ee000fb4243,
-    type: 2}
-  m_PrefabInternal: {fileID: 1484279150}
-  m_GameObject: {fileID: 478672352}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 734504342}
-  - {fileID: 492701920}
-  m_Father: {fileID: 0}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &488360706
 GameObject:
   m_ObjectHideFlags: 0
@@ -462,10 +416,10 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 229025308}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
@@ -515,91 +469,6 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 488360706}
---- !u!1 &492701916
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1000013615056792, guid: b2db04283121ca74495c2ee000fb4243,
-    type: 2}
-  m_PrefabInternal: {fileID: 1484279150}
-  serializedVersion: 4
-  m_Component:
-  - 4: {fileID: 492701920}
-  - 33: {fileID: 492701919}
-  - 135: {fileID: 492701918}
-  - 23: {fileID: 492701917}
-  m_Layer: 2
-  m_Name: CursorOffHolograms
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!23 &492701917
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 23000011471158336, guid: b2db04283121ca74495c2ee000fb4243,
-    type: 2}
-  m_PrefabInternal: {fileID: 1484279150}
-  m_GameObject: {fileID: 492701916}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
-  m_SubsetIndices: 
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 1
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
---- !u!135 &492701918
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 135000012439094316, guid: b2db04283121ca74495c2ee000fb4243,
-    type: 2}
-  m_PrefabInternal: {fileID: 1484279150}
-  m_GameObject: {fileID: 492701916}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.5
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!33 &492701919
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 33000010463283372, guid: b2db04283121ca74495c2ee000fb4243,
-    type: 2}
-  m_PrefabInternal: {fileID: 1484279150}
-  m_GameObject: {fileID: 492701916}
-  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &492701920
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 4000013144497514, guid: b2db04283121ca74495c2ee000fb4243,
-    type: 2}
-  m_PrefabInternal: {fileID: 1484279150}
-  m_GameObject: {fileID: 492701916}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.005, y: 0.005, z: 0.005}
-  m_Children:
-  - {fileID: 1342176771}
-  m_Father: {fileID: 478672354}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &661260205
 GameObject:
   m_ObjectHideFlags: 0
@@ -658,80 +527,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 8
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &734504339
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1000012100030190, guid: b2db04283121ca74495c2ee000fb4243,
-    type: 2}
-  m_PrefabInternal: {fileID: 1484279150}
-  serializedVersion: 4
-  m_Component:
-  - 4: {fileID: 734504342}
-  - 33: {fileID: 734504341}
-  - 23: {fileID: 734504340}
-  m_Layer: 2
-  m_Name: CursorOnHolograms
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!23 &734504340
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 23000013452343876, guid: b2db04283121ca74495c2ee000fb4243,
-    type: 2}
-  m_PrefabInternal: {fileID: 1484279150}
-  m_GameObject: {fileID: 734504339}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_Materials:
-  - {fileID: 2100000, guid: a2c9c4679b0c3cf47b3ba3a449c985d7, type: 2}
-  m_SubsetIndices: 
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_SelectedWireframeHidden: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
---- !u!33 &734504341
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 33000011299448354, guid: b2db04283121ca74495c2ee000fb4243,
-    type: 2}
-  m_PrefabInternal: {fileID: 1484279150}
-  m_GameObject: {fileID: 734504339}
-  m_Mesh: {fileID: 4300000, guid: c1000081192be7347a0ad0c380ed6171, type: 3}
---- !u!4 &734504342
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 4000011283192616, guid: b2db04283121ca74495c2ee000fb4243,
-    type: 2}
-  m_PrefabInternal: {fileID: 1484279150}
-  m_GameObject: {fileID: 734504339}
-  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1.15, y: 1.15, z: 2.5}
-  m_Children: []
-  m_Father: {fileID: 478672354}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
 --- !u!1 &770488534
 GameObject:
   m_ObjectHideFlags: 0
@@ -756,11 +555,11 @@ RectTransform:
   m_LocalRotation: {x: 0, y: -0.38268343, z: 0, w: 0.92387956}
   m_LocalPosition: {x: 0, y: 0, z: 1.2}
   m_LocalScale: {x: 0.001, y: 0.001, z: 0.001}
+  m_LocalEulerAnglesHint: {x: 0, y: -45, z: 0}
   m_Children:
   - {fileID: 1871194243}
   m_Father: {fileID: 0}
   m_RootOrder: 9
-  m_LocalEulerAnglesHint: {x: 0, y: -45, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: -1.2, y: 0}
@@ -865,75 +664,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0.6, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1870424961}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1342176770
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 1000013763932778, guid: b2db04283121ca74495c2ee000fb4243,
-    type: 2}
-  m_PrefabInternal: {fileID: 1484279150}
-  serializedVersion: 4
-  m_Component:
-  - 4: {fileID: 1342176771}
-  - 108: {fileID: 1342176772}
-  m_Layer: 2
-  m_Name: Point light
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1342176771
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 4000010267160112, guid: b2db04283121ca74495c2ee000fb4243,
-    type: 2}
-  m_PrefabInternal: {fileID: 1484279150}
-  m_GameObject: {fileID: 1342176770}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 492701920}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!108 &1342176772
-Light:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 108000011213487996, guid: b2db04283121ca74495c2ee000fb4243,
-    type: 2}
-  m_PrefabInternal: {fileID: 1484279150}
-  m_GameObject: {fileID: 1342176770}
-  m_Enabled: 1
-  serializedVersion: 7
-  m_Type: 2
-  m_Color: {r: 0.8039216, g: 0.6431373, b: 0.9529412, a: 1}
-  m_Intensity: 1
-  m_Range: 0.05
-  m_SpotAngle: 30
-  m_CookieSize: 10
-  m_Shadows:
-    m_Type: 0
-    m_Resolution: -1
-    m_Strength: 1
-    m_Bias: 0.05
-    m_NormalBias: 0.4
-    m_NearPlane: 0.2
-  m_Cookie: {fileID: 0}
-  m_DrawHalo: 1
-  m_Flare: {fileID: 0}
-  m_RenderMode: 0
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_Lightmapping: 4
-  m_AreaSize: {x: 1, y: 1}
-  m_BounceIntensity: 1
-  m_ShadowRadius: 0
-  m_ShadowAngle: 0
 --- !u!1 &1387631413
 GameObject:
   m_ObjectHideFlags: 0
@@ -959,10 +693,10 @@ Transform:
   m_LocalRotation: {x: 0.47806358, y: -0.22489665, z: 0.12809673, w: 0.8393259}
   m_LocalPosition: {x: 0, y: 2, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 59.33, y: -30, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 59.33, y: -30, z: 0}
 --- !u!108 &1387631415
 Light:
   m_ObjectHideFlags: 0
@@ -980,6 +714,7 @@ Light:
   m_Shadows:
     m_Type: 0
     m_Resolution: -1
+    m_CustomResolution: -1
     m_Strength: 1
     m_Bias: 0.05
     m_NormalBias: 0.4
@@ -1037,7 +772,6 @@ Prefab:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: b2db04283121ca74495c2ee000fb4243, type: 2}
-  m_RootGameObject: {fileID: 478672352}
   m_IsPrefabParent: 0
 --- !u!1 &1655140847
 GameObject:
@@ -1071,6 +805,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   audioSource: {fileID: 1655140849}
+  voice: 3
 --- !u!82 &1655140849
 AudioSource:
   m_ObjectHideFlags: 0
@@ -1202,10 +937,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 1.2, y: 0, z: -1.2}
   m_LocalScale: {x: 0.2, y: 0.2, z: 0.2}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 7
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1680871006
 GameObject:
   m_ObjectHideFlags: 0
@@ -1234,10 +969,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1680871008
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1262,6 +997,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   audioSource: {fileID: 794123043}
+  voice: 0
 --- !u!114 &1680871012
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1343,6 +1079,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   audioSource: {fileID: 1814075188}
+  voice: 2
 --- !u!82 &1814075188
 AudioSource:
   m_ObjectHideFlags: 0
@@ -1474,10 +1211,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 1.2}
   m_LocalScale: {x: 0.2, y: 0.2, z: 0.2}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 6
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1870424956
 GameObject:
   m_ObjectHideFlags: 0
@@ -1561,11 +1298,11 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 794123044}
   m_Father: {fileID: 0}
   m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1871194242
 GameObject:
   m_ObjectHideFlags: 0
@@ -1593,11 +1330,11 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 229025308}
   m_Father: {fileID: 770488535}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 50, y: 50}

--- a/Assets/HoloToolkit/Utilities/Tests/TextToSpeechManagerTest.cs
+++ b/Assets/HoloToolkit/Utilities/Tests/TextToSpeechManagerTest.cs
@@ -13,11 +13,19 @@ public class TextToSpeechManagerTest : MonoBehaviour
     // Use this for initialization
     void Start ()
     {
+        #if WINDOWS_UWP
+        // var synthesizer = new Windows.Media.SpeechSynthesis.SpeechSynthesizer();
+        var voices = Windows.Media.SpeechSynthesis.SpeechSynthesizer.AllVoices;
+        foreach (var voice in voices)
+        {
+            Debug.Log("voice = " + voice.DisplayName);
+        }
+        #endif
+
         // Set up a GestureRecognizer to detect Select gestures.
         gestureRecognizer = new GestureRecognizer();
         gestureRecognizer.TappedEvent += GestureRecognizer_TappedEvent;
         gestureRecognizer.StartCapturingGestures();
-
     }
 
     private void GestureRecognizer_TappedEvent(InteractionSourceKind source, int tapCount, Ray headRay)
@@ -39,7 +47,14 @@ public class TextToSpeechManagerTest : MonoBehaviour
             // This voice will appear to emanate from the object.
             if (tts != null)
             {
-                tts.SpeakText("This voice should sound like it's coming from the object you clicked. Feel free to walk around and listen from different angles.");
+                // Get the name
+                var voiceName = Enum.GetName(typeof(TextToSpeechVoice), tts.voice);
+
+                // Create message
+                var msg = string.Format("This is the {0} voice. It should sound like it's coming from the object you clicked. Feel free to walk around and listen from different angles.", voiceName);
+
+                // Speak message
+                tts.SpeakText(msg);
             }
         }
     }

--- a/Assets/HoloToolkit/Utilities/Tests/TextToSpeechManagerTest.cs
+++ b/Assets/HoloToolkit/Utilities/Tests/TextToSpeechManagerTest.cs
@@ -13,15 +13,6 @@ public class TextToSpeechManagerTest : MonoBehaviour
     // Use this for initialization
     void Start ()
     {
-        #if WINDOWS_UWP
-        // var synthesizer = new Windows.Media.SpeechSynthesis.SpeechSynthesizer();
-        var voices = Windows.Media.SpeechSynthesis.SpeechSynthesizer.AllVoices;
-        foreach (var voice in voices)
-        {
-            Debug.Log("voice = " + voice.DisplayName);
-        }
-        #endif
-
         // Set up a GestureRecognizer to detect Select gestures.
         gestureRecognizer = new GestureRecognizer();
         gestureRecognizer.TappedEvent += GestureRecognizer_TappedEvent;
@@ -48,7 +39,7 @@ public class TextToSpeechManagerTest : MonoBehaviour
             if (tts != null)
             {
                 // Get the name
-                var voiceName = Enum.GetName(typeof(TextToSpeechVoice), tts.voice);
+                var voiceName = Enum.GetName(typeof(TextToSpeechVoice), tts.Voice);
 
                 // Create message
                 var msg = string.Format("This is the {0} voice. It should sound like it's coming from the object you clicked. Feel free to walk around and listen from different angles.", voiceName);


### PR DESCRIPTION
This pull request fixes #220. It adds a dropdown in the inspector for TextToSpeechManager that includes 4 options:

1. Default
2. David
3. Mark
4. Zira

This list unfortunately cannot be dynamic because we can't execute UWP APIs in the Unity Editor. Even if we could, the voices available on the desktop will likely not match those on the HoloLens. Therefore, this list is hard coded. If we find the list changing frequently in the future (unlikely) we can add an option for typing in the voice name.

At runtime, if the dropdown was set to Default no extra code will be run and the behavior will be as before. If the dropdown is set to anything other than Default, the installed voices are searched for one that matches the selected name. If the voice is found, it's used. If the voice is not found, an error is logged but the default voice is still used.

This pull request also includes an update to the test scene. Now each of the three cubes has a unique voice and all three cubes speak their voice name as part of their message.