### PR TITLE
Focus object fix

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/GestureManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/GestureManager.cs
@@ -116,9 +116,7 @@ namespace HoloToolkit.Unity
             gestureRecognizer.StartCapturingGestures();
             manipulationRecognizer.StartCapturingGestures();
         }
-
-
-
+        
         private void InteractionManager_SourcePressed(InteractionSourceState state)
         {
             if (!HandPressed)
@@ -225,6 +223,7 @@ namespace HoloToolkit.Unity
                 // If the currently focused object doesn't match the old focused object, cancel the current gesture.
                 // Start looking for new gestures.  This is to prevent applying gestures from one hologram to another.
                 gestureRecognizer.CancelGestures();
+                FocusedObject = newFocusedObject;
                 gestureRecognizer.StartCapturingGestures();
             }
 
@@ -234,7 +233,6 @@ namespace HoloToolkit.Unity
                 OnTap();
             }
 #endif
-            FocusedObject = newFocusedObject;
         }
 
         void OnDestroy()

--- a/Assets/HoloToolkit/Input/Scripts/GestureManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/GestureManager.cs
@@ -48,7 +48,7 @@ namespace HoloToolkit.Unity
         /// If its null, then the gazed at object will be selected.
         /// </summary>
         public GameObject OverrideFocusedObject { get; set; }
-        
+
         /// <summary>
         /// Gets the currently focused object, or null if none.
         /// </summary>
@@ -156,7 +156,7 @@ namespace HoloToolkit.Unity
         {
             if (FocusedObject != null)
             {
-                FocusedObject.SendMessage("OnSelect");
+                FocusedObject.SendMessage("OnSelect", SendMessageOptions.DontRequireReceiver);
             }
         }
 
@@ -204,7 +204,7 @@ namespace HoloToolkit.Unity
 
         void LateUpdate()
         {
-            GameObject oldFocusedObject = FocusedObject;
+            GameObject newFocusedObject;
 
             if (GazeManager.Instance.Hit &&
                 OverrideFocusedObject == null &&
@@ -212,15 +212,15 @@ namespace HoloToolkit.Unity
             {
                 // If gaze hits a hologram, set the focused object to that game object.
                 // Also if the caller has not decided to override the focused object.
-                FocusedObject = GazeManager.Instance.HitInfo.collider.gameObject;
+                newFocusedObject = GazeManager.Instance.HitInfo.collider.gameObject;
             }
             else
             {
                 // If our gaze doesn't hit a hologram, set the focused object to null or override focused object.
-                FocusedObject = OverrideFocusedObject;
+                newFocusedObject = OverrideFocusedObject;
             }
 
-            if (FocusedObject != oldFocusedObject)
+            if (FocusedObject != newFocusedObject)
             {
                 // If the currently focused object doesn't match the old focused object, cancel the current gesture.
                 // Start looking for new gestures.  This is to prevent applying gestures from one hologram to another.
@@ -234,6 +234,7 @@ namespace HoloToolkit.Unity
                 OnTap();
             }
 #endif
+            FocusedObject = newFocusedObject;
         }
 
         void OnDestroy()


### PR DESCRIPTION
When looking at adding events for gesture recognition start and end so that my UI elements could display a visual down and up state, I noticed that when focused changed, the new focused object was being set before the gestures were canceled. Canceling gestures sends the recognition end event, but to the new focused object.

While I was updating the logic, adding the "SendMessageOptions.DontRequireReceiver" to the OnSelect message seemed to match the intent that any object may or may not be listening for the OnSelect message.