### PR TITLE
Basic cursor null ref and bitwise fixes

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/BasicCursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/BasicCursor.cs
@@ -28,7 +28,7 @@ namespace HoloToolkit.Unity
 
         private bool hasLoggedGazeManagerError;
 
-        private GazeManager gaseManager;
+        private GazeManager gazeManager;
 
         protected virtual void Awake()
         {
@@ -49,9 +49,9 @@ namespace HoloToolkit.Unity
 
         private bool GetGazeManagerReference()
         {
-            gaseManager = GazeManager.Instance;
+            gazeManager = GazeManager.Instance;
 
-            if (gaseManager == null)
+            if (gazeManager == null)
             {
                 return false;
             }
@@ -90,7 +90,7 @@ namespace HoloToolkit.Unity
                 return;
             }
 
-            if (gaseManager == null)
+            if (gazeManager == null)
             {
                 if (!GetGazeManagerReference())
                 {

--- a/Assets/HoloToolkit/Input/Scripts/BasicCursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/BasicCursor.cs
@@ -93,7 +93,9 @@ namespace HoloToolkit.Unity
             if (gazeManagerReference == null)
             {
                 if (!GetGazeManagerReference())
+                {
                     return;
+                }
             }
 
             // Calculate the raycast result

--- a/Assets/HoloToolkit/Input/Scripts/BasicCursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/BasicCursor.cs
@@ -28,15 +28,15 @@ namespace HoloToolkit.Unity
 
         private bool hasLoggedGazeManagerError;
 
-        protected virtual void Awake()
+        protected virtual void Start()
         {
-            if ((GazeManager.Instance.RaycastLayerMask & this.gameObject.layer) == 0)
+            if ((GazeManager.Instance.RaycastLayerMask & (1 << gameObject.layer)) != 0)
             {
                 Debug.LogError("The cursor has a layer that is checked in the GazeManager's Raycast Layer Mask.  Change the cursor layer (e.g.: to Ignore Raycast) or uncheck the layer in GazeManager: " +
-                    LayerMask.LayerToName(this.gameObject.layer));
+                    LayerMask.LayerToName(gameObject.layer));
             }
 
-            meshRenderer = this.gameObject.GetComponent<MeshRenderer>();
+            meshRenderer = gameObject.GetComponent<MeshRenderer>();
 
             if (meshRenderer == null)
             {
@@ -48,7 +48,7 @@ namespace HoloToolkit.Unity
             meshRenderer.enabled = false;
 
             // Cache the cursor default rotation so the cursor can be rotated with respect to the original orientation.
-            cursorDefaultRotation = this.gameObject.transform.rotation;
+            cursorDefaultRotation = gameObject.transform.rotation;
         }
 
         protected virtual RaycastResult CalculateRayIntersect()
@@ -83,11 +83,11 @@ namespace HoloToolkit.Unity
             meshRenderer.enabled = rayResult.Hit;
 
             // Place the cursor at the calculated position.
-            this.gameObject.transform.position = rayResult.Position + rayResult.Normal * DistanceFromCollision;
+            gameObject.transform.position = rayResult.Position + rayResult.Normal * DistanceFromCollision;
 
             // Reorient the cursor to match the hit object normal.
-            this.gameObject.transform.up = rayResult.Normal;
-            this.gameObject.transform.rotation *= cursorDefaultRotation;
+            gameObject.transform.up = rayResult.Normal;
+            gameObject.transform.rotation *= cursorDefaultRotation;
         }
     }
 }

--- a/Assets/HoloToolkit/Input/Scripts/BasicCursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/BasicCursor.cs
@@ -28,12 +28,6 @@ namespace HoloToolkit.Unity
 
         private GazeManager gazeManager;
 
-        /// <summary>
-        /// The number of frames to wait until we get our GazeManager reference before
-        /// throwing an error about it being missing in the scene.
-        /// </summary>
-        private int framesBeforeError = 10;
-
         protected virtual void Awake()
         {
             meshRenderer = gameObject.GetComponent<MeshRenderer>();
@@ -51,23 +45,13 @@ namespace HoloToolkit.Unity
             cursorDefaultRotation = gameObject.transform.rotation;
         }
 
-        private bool GetGazeManagerReference()
+        protected virtual void Start()
         {
             gazeManager = GazeManager.Instance;
 
             if (gazeManager == null)
             {
-                if (framesBeforeError > 0)
-                {
-                    framesBeforeError--;
-                }
-
-                if (framesBeforeError == 0)
-                {
-                    Debug.LogError("Must have a GazeManager somewhere in the scene.");
-                }
-
-                return false;
+                Debug.LogError("Must have a GazeManager somewhere in the scene.");
             }
 
             if ((GazeManager.Instance.RaycastLayerMask & (1 << gameObject.layer)) != 0)
@@ -75,8 +59,6 @@ namespace HoloToolkit.Unity
                 Debug.LogError("The cursor has a layer that is checked in the GazeManager's Raycast Layer Mask.  Change the cursor layer (e.g.: to Ignore Raycast) or uncheck the layer in GazeManager: " +
                     LayerMask.LayerToName(gameObject.layer));
             }
-
-            return true;
         }
 
         protected virtual RaycastResult CalculateRayIntersect()
@@ -90,17 +72,9 @@ namespace HoloToolkit.Unity
 
         protected virtual void LateUpdate()
         {
-            if (meshRenderer == null)
+            if (meshRenderer == null || gazeManager == null)
             {
                 return;
-            }
-
-            if (gazeManager == null)
-            {
-                if (!GetGazeManagerReference())
-                {
-                    return;
-                }
             }
 
             // Calculate the raycast result

--- a/Assets/HoloToolkit/Input/Scripts/BasicCursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/BasicCursor.cs
@@ -26,9 +26,13 @@ namespace HoloToolkit.Unity
 
         private MeshRenderer meshRenderer;
 
-        private bool hasLoggedGazeManagerError;
-
         private GazeManager gazeManager;
+
+        /// <summary>
+        /// The number of frames to wait until we get our GazeManager reference before
+        /// throwing an error about it being missing in the scene.
+        /// </summary>
+        private int framesBeforeError = 10;
 
         protected virtual void Awake()
         {
@@ -53,6 +57,16 @@ namespace HoloToolkit.Unity
 
             if (gazeManager == null)
             {
+                if (framesBeforeError > 0)
+                {
+                    framesBeforeError--;
+                }
+
+                if (framesBeforeError == 0)
+                {
+                    Debug.LogError("Must have a GazeManager somewhere in the scene.");
+                }
+
                 return false;
             }
 
@@ -68,15 +82,6 @@ namespace HoloToolkit.Unity
         protected virtual RaycastResult CalculateRayIntersect()
         {
             RaycastResult result = new RaycastResult();
-            if (GazeManager.Instance == null)
-            {
-                if (!hasLoggedGazeManagerError)
-                {
-                    Debug.LogError("Must have a GazeManager somewhere in the scene.");
-                    hasLoggedGazeManagerError = true;
-                }
-                return result;
-            }
             result.Hit = GazeManager.Instance.Hit;
             result.Position = GazeManager.Instance.Position;
             result.Normal = GazeManager.Instance.Normal;

--- a/Assets/HoloToolkit/Input/Scripts/BasicCursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/BasicCursor.cs
@@ -28,14 +28,10 @@ namespace HoloToolkit.Unity
 
         private bool hasLoggedGazeManagerError;
 
-        protected virtual void Start()
-        {
-            if ((GazeManager.Instance.RaycastLayerMask & (1 << gameObject.layer)) != 0)
-            {
-                Debug.LogError("The cursor has a layer that is checked in the GazeManager's Raycast Layer Mask.  Change the cursor layer (e.g.: to Ignore Raycast) or uncheck the layer in GazeManager: " +
-                    LayerMask.LayerToName(gameObject.layer));
-            }
+        private GazeManager gazeManagerReference;
 
+        protected virtual void Awake()
+        {
             meshRenderer = gameObject.GetComponent<MeshRenderer>();
 
             if (meshRenderer == null)
@@ -49,6 +45,24 @@ namespace HoloToolkit.Unity
 
             // Cache the cursor default rotation so the cursor can be rotated with respect to the original orientation.
             cursorDefaultRotation = gameObject.transform.rotation;
+        }
+
+        private bool GetGazeManagerReference()
+        {
+            gazeManagerReference = GazeManager.Instance;
+
+            if (gazeManagerReference == null)
+            {
+                return false;
+            }
+
+            if ((GazeManager.Instance.RaycastLayerMask & (1 << gameObject.layer)) != 0)
+            {
+                Debug.LogError("The cursor has a layer that is checked in the GazeManager's Raycast Layer Mask.  Change the cursor layer (e.g.: to Ignore Raycast) or uncheck the layer in GazeManager: " +
+                    LayerMask.LayerToName(gameObject.layer));
+            }
+
+            return true;
         }
 
         protected virtual RaycastResult CalculateRayIntersect()
@@ -74,6 +88,12 @@ namespace HoloToolkit.Unity
             if (meshRenderer == null)
             {
                 return;
+            }
+
+            if (gazeManagerReference == null)
+            {
+                if (!GetGazeManagerReference())
+                    return;
             }
 
             // Calculate the raycast result

--- a/Assets/HoloToolkit/Input/Scripts/BasicCursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/BasicCursor.cs
@@ -28,7 +28,7 @@ namespace HoloToolkit.Unity
 
         private bool hasLoggedGazeManagerError;
 
-        private GazeManager gazeManagerReference;
+        private GazeManager gaseManager;
 
         protected virtual void Awake()
         {
@@ -49,9 +49,9 @@ namespace HoloToolkit.Unity
 
         private bool GetGazeManagerReference()
         {
-            gazeManagerReference = GazeManager.Instance;
+            gaseManager = GazeManager.Instance;
 
-            if (gazeManagerReference == null)
+            if (gaseManager == null)
             {
                 return false;
             }
@@ -90,7 +90,7 @@ namespace HoloToolkit.Unity
                 return;
             }
 
-            if (gazeManagerReference == null)
+            if (gaseManager == null)
             {
                 if (!GetGazeManagerReference())
                 {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/HoloToolkit-Unity/issues/246 Null Ref on Awake when looking for `GazeManager.Instance`.
Fixes https://github.com/Microsoft/HoloToolkit-Unity/issues/197 Layer raycast mask to use bitwise op for calculation.