### PR TITLE
Adding note related to building project

### DIFF
--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -51,7 +51,10 @@ You will probably want to add `ManualCameraControl.cs` (found under
 
 Deploy to the emulator or device.
 
-**NOTE**: Make sure to build/run your project in x86 and not in ARM so you can properly get the DLLs required
+# Deploying your HoloLens app using Visual Studio
+ 1. Select **x86** in your build configuration
+ 2. Select emulator or the device that you're using
+ 3. Run the app
 
 
 

--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -51,5 +51,7 @@ You will probably want to add `ManualCameraControl.cs` (found under
 
 Deploy to the emulator or device.
 
+**NOTE**: Make sure to build/run your project in x86 and not in ARM so you can properly get the DLLs required
+
 
 


### PR DESCRIPTION
Added note regarding the architecture type needed to properly build/run the project from the examples. I've added this because in our case, when we try to build and run the project in ARM (because that's the default arch type when we open it in Visual Studio) we're having errors when it comes to getting the required DLLs