### PR TITLE
Fixed angular size expanded

### DIFF
--- a/Assets/HoloToolkit/Utilities/Scripts/FixedAngularSize.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/FixedAngularSize.cs
@@ -12,48 +12,49 @@ namespace HoloToolkit.Unity
     /// </summary>
     public class FixedAngularSize : MonoBehaviour
     {
-        /// <summary>
-        /// Off sets the scale ratio so that text does not scale down so much. (Set to zero for linear scaling)
-        /// </summary>
+        [Tooltip("Off sets the scale ratio so that text does not scale down too much. (Set to zero for linear scaling)")]
         public float OverrideSizeRatio = 0;
+
         // The ratio between the transform's local scale and its starting
         // distance from the camera.
+        private Vector3 defaultSizeRatios;
         private float startingDistance;
         private Vector3 startingScale;
 
-        void Start()
+        private void Start()
         {
             // Calculate the XYZ ratios for the transform's localScale over its
             // initial distance from the camera.
             startingDistance = Vector3.Distance(Camera.main.transform.position, transform.position);
             startingScale = transform.localScale;
 
-            if (startingDistance > 0.0f)
-            {
-                if (OverrideSizeRatio == 0)
-                {
-                    // set to a linear scale ratio
-                    OverrideSizeRatio = 1 / startingDistance;
-                }
-            }
-            else
-            {
-                // If the transform and the camera are both in the same
-                // position (that is, the distance between them is zero),
-                // disable this Behaviour so we don't get a DivideByZero
-                // error later on.
-                enabled = false;
-#if UNITY_EDITOR
-                Debug.LogWarning("The object and the camera are in the same position at Start(). The attached FixedAngularSize Behaviour is now disabled.");
-#endif // UNITY_EDITOR
-            }
+            SetSizeRatio(OverrideSizeRatio);
         }
 
+        /// <summary>
+        /// Manually update the OverrideSizeRatio during runtime or through UnityEvents in the editor
+        /// </summary>
+        /// <param name="ratio"> 0 - 1 : Use 0 for linear scaling</param>
         public void SetSizeRatio(float ratio)
         {
             if (ratio == 0)
             {
-                OverrideSizeRatio = 1 / startingDistance;
+                if (startingDistance > 0.0f)
+                {
+                    // set to a linear scale ratio
+                    OverrideSizeRatio = 1 / startingDistance;
+                }
+                else
+                {
+                    // If the transform and the camera are both in the same
+                    // position (that is, the distance between them is zero),
+                    // disable this Behaviour so we don't get a DivideByZero
+                    // error later on.
+                    enabled = false;
+#if UNITY_EDITOR
+                    Debug.LogWarning("The object and the camera are in the same position at Start(). The attached FixedAngularSize Behaviour is now disabled.");
+#endif // UNITY_EDITOR
+                }
             }
             else
             {
@@ -61,13 +62,13 @@ namespace HoloToolkit.Unity
             }
         }
 
-        void Update()
+        private void Update()
         {
             float distanceToHologram = Vector3.Distance(Camera.main.transform.position, transform.position);
             // create an offset ratio based on the starting position. This value creates a new angle that pivots
             // on the starting position that is more or less drastic than the normal scale ratio.
-            float CurvedRatio = 1 - startingDistance * OverrideSizeRatio;
-            transform.localScale = startingScale * (distanceToHologram * OverrideSizeRatio + CurvedRatio);
+            float curvedRatio = 1 - startingDistance * OverrideSizeRatio;
+            transform.localScale = startingScale * (distanceToHologram * OverrideSizeRatio + curvedRatio);
         }
     }
 }

--- a/Assets/HoloToolkit/Utilities/Scripts/FixedAngularSize.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/FixedAngularSize.cs
@@ -12,20 +12,29 @@ namespace HoloToolkit.Unity
     /// </summary>
     public class FixedAngularSize : MonoBehaviour
     {
+        /// <summary>
+        /// Off sets the scale ratio so that text does not scale down so much. (Set to zero for linear scaling)
+        /// </summary>
+        public float OverrideSizeRatio = 0;
         // The ratio between the transform's local scale and its starting
         // distance from the camera.
-        private Vector3 defaultSizeRatios;
+        private float startingDistance;
+        private Vector3 startingScale;
 
         void Start()
         {
             // Calculate the XYZ ratios for the transform's localScale over its
             // initial distance from the camera.
-            float startingDistance = Vector3.Distance(Camera.main.transform.position, transform.position);
-            if (startingDistance > 0.0f)
+            startingDistance = Vector3.Distance(Camera.main.transform.position, transform.position);
+            startingScale = transform.localScale;
+
+            if (OverrideSizeRatio == 0)
             {
-                defaultSizeRatios = transform.localScale / startingDistance;
+                // set to a linear scale ratio
+                OverrideSizeRatio = 1 / startingDistance;
             }
-            else
+
+            if (startingDistance < 0.0f)
             {
                 // If the transform and the camera are both in the same
                 // position (that is, the distance between them is zero),
@@ -38,10 +47,25 @@ namespace HoloToolkit.Unity
             }
         }
 
+        public void SetSizeRatio(float ratio)
+        {
+            if (ratio == 0)
+            {
+                OverrideSizeRatio = 1 / startingDistance;
+            }
+            else
+            {
+                OverrideSizeRatio = ratio;
+            }
+        }
+
         void Update()
         {
             float distanceToHologram = Vector3.Distance(Camera.main.transform.position, transform.position);
-            transform.localScale = defaultSizeRatios * distanceToHologram;
+            // create an offset ratio based on the starting position. This value creates a new angle that pivots
+            // on the starting position that is more or less drastic than the normal scale ratio.
+            float CurvedRatio = 1 - startingDistance * OverrideSizeRatio;
+            transform.localScale = startingScale * (distanceToHologram * OverrideSizeRatio + CurvedRatio);
         }
     }
 }

--- a/Assets/HoloToolkit/Utilities/Scripts/FixedAngularSize.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/FixedAngularSize.cs
@@ -13,11 +13,10 @@ namespace HoloToolkit.Unity
     public class FixedAngularSize : MonoBehaviour
     {
         [Tooltip("Off sets the scale ratio so that text does not scale down too much. (Set to zero for linear scaling)")]
-        public float OverrideSizeRatio = 0;
+        public float SizeRatio = 0;
 
         // The ratio between the transform's local scale and its starting
         // distance from the camera.
-        private Vector3 defaultSizeRatios;
         private float startingDistance;
         private Vector3 startingScale;
 
@@ -28,7 +27,7 @@ namespace HoloToolkit.Unity
             startingDistance = Vector3.Distance(Camera.main.transform.position, transform.position);
             startingScale = transform.localScale;
 
-            SetSizeRatio(OverrideSizeRatio);
+            SetSizeRatio(SizeRatio);
         }
 
         /// <summary>
@@ -42,7 +41,7 @@ namespace HoloToolkit.Unity
                 if (startingDistance > 0.0f)
                 {
                     // set to a linear scale ratio
-                    OverrideSizeRatio = 1 / startingDistance;
+                    SizeRatio = 1 / startingDistance;
                 }
                 else
                 {
@@ -58,7 +57,7 @@ namespace HoloToolkit.Unity
             }
             else
             {
-                OverrideSizeRatio = ratio;
+                SizeRatio = ratio;
             }
         }
 
@@ -67,8 +66,8 @@ namespace HoloToolkit.Unity
             float distanceToHologram = Vector3.Distance(Camera.main.transform.position, transform.position);
             // create an offset ratio based on the starting position. This value creates a new angle that pivots
             // on the starting position that is more or less drastic than the normal scale ratio.
-            float curvedRatio = 1 - startingDistance * OverrideSizeRatio;
-            transform.localScale = startingScale * (distanceToHologram * OverrideSizeRatio + curvedRatio);
+            float curvedRatio = 1 - startingDistance * SizeRatio;
+            transform.localScale = startingScale * (distanceToHologram * SizeRatio + curvedRatio);
         }
     }
 }

--- a/Assets/HoloToolkit/Utilities/Scripts/FixedAngularSize.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/FixedAngularSize.cs
@@ -34,7 +34,7 @@ namespace HoloToolkit.Unity
                 OverrideSizeRatio = 1 / startingDistance;
             }
 
-            if (startingDistance < 0.0f)
+            if (startingDistance <= 0.0f)
             {
                 // If the transform and the camera are both in the same
                 // position (that is, the distance between them is zero),

--- a/Assets/HoloToolkit/Utilities/Scripts/FixedAngularSize.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/FixedAngularSize.cs
@@ -28,13 +28,15 @@ namespace HoloToolkit.Unity
             startingDistance = Vector3.Distance(Camera.main.transform.position, transform.position);
             startingScale = transform.localScale;
 
-            if (OverrideSizeRatio == 0)
+            if (startingDistance > 0.0f)
             {
-                // set to a linear scale ratio
-                OverrideSizeRatio = 1 / startingDistance;
+                if (OverrideSizeRatio == 0)
+                {
+                    // set to a linear scale ratio
+                    OverrideSizeRatio = 1 / startingDistance;
+                }
             }
-
-            if (startingDistance <= 0.0f)
+            else
             {
                 // If the transform and the camera are both in the same
                 // position (that is, the distance between them is zero),

--- a/Assets/HoloToolkit/Utilities/Tests/FixedAngularSize.unity
+++ b/Assets/HoloToolkit/Utilities/Tests/FixedAngularSize.unity
@@ -1,0 +1,360 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+SceneSettings:
+  m_ObjectHideFlags: 0
+  m_PVSData: 
+  m_PVSObjectsArray: []
+  m_PVSPortalsArray: []
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 7
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 7
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_TemporalCoherenceThreshold: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 1
+  m_LightmapEditorSettings:
+    serializedVersion: 4
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_TextureWidth: 1024
+    m_TextureHeight: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_DirectLightInLightProbes: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+  m_LightingDataAsset: {fileID: 0}
+  m_RuntimeCPUUsage: 25
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    accuratePlacement: 0
+    minRegionArea: 2
+    cellSize: 0.16666667
+    manualCellSize: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &1391723345
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 1391723350}
+  - 20: {fileID: 1391723349}
+  - 92: {fileID: 1391723348}
+  - 124: {fileID: 1391723347}
+  - 81: {fileID: 1391723346}
+  - 114: {fileID: 1391723351}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &1391723346
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1391723345}
+  m_Enabled: 1
+--- !u!124 &1391723347
+Behaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1391723345}
+  m_Enabled: 1
+--- !u!92 &1391723348
+Behaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1391723345}
+  m_Enabled: 1
+--- !u!20 &1391723349
+Camera:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1391723345}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.85
+  far clip plane: 1000
+  field of view: 16
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+  m_StereoMirrorMode: 0
+--- !u!4 &1391723350
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1391723345}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+--- !u!114 &1391723351
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1391723345}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 120ba207cff42584584563bcf18c124f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ExtraMouseSensitivityScale: 3
+  DefaultMouseSensitivity: 0.1
+  MouseLookButton: 4
+  IsControllerLookInverted: 1
+  CurrentControlMode: 0
+  FastControlKey: 305
+  ControlSlowSpeed: 0.1
+  ControlFastSpeed: 1
+  MoveHorizontal: Horizontal
+  MoveVertical: Vertical
+  MouseX: Mouse X
+  MouseY: Mouse Y
+  LookHorizontal: LookHorizontal
+  LookVertical: LookVertical
+--- !u!1 &1830650450
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 1830650454}
+  - 33: {fileID: 1830650453}
+  - 65: {fileID: 1830650452}
+  - 23: {fileID: 1830650451}
+  - 114: {fileID: 1830650455}
+  m_Layer: 0
+  m_Name: FixedSizeUIElement
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!23 &1830650451
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1830650450}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: 876ee7c44387b01479ea2c04cff7308e, type: 2}
+  m_SubsetIndices: 
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedWireframeHidden: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+--- !u!65 &1830650452
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1830650450}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &1830650453
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1830650450}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1830650454
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1830650450}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 1}
+  m_LocalScale: {x: 0.2, y: 0.2, z: 0.2}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+--- !u!114 &1830650455
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1830650450}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8238048e62b3fb047bc5dd12384f280a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  SizeRatio: 0
+--- !u!1 &2020354874
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 2020354876}
+  - 108: {fileID: 2020354875}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &2020354875
+Light:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2020354874}
+  m_Enabled: 1
+  serializedVersion: 7
+  m_Type: 1
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_Lightmapping: 4
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &2020354876
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2020354874}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1

--- a/Assets/HoloToolkit/Utilities/Tests/FixedAngularSize.unity.meta
+++ b/Assets/HoloToolkit/Utilities/Tests/FixedAngularSize.unity.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 532576065751fd544816d8d48c4d8858
+timeCreated: 1476915210
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/GraphicsSettings.asset
+++ b/ProjectSettings/GraphicsSettings.asset
@@ -39,10 +39,10 @@ GraphicsSettings:
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}
   m_ShaderSettings_Tier1:
-    useCascadedShadowMaps: 1
-    standardShaderQuality: 2
-    useReflectionProbeBoxProjection: 1
-    useReflectionProbeBlending: 1
+    useCascadedShadowMaps: 0
+    standardShaderQuality: 0
+    useReflectionProbeBoxProjection: 0
+    useReflectionProbeBlending: 0
   m_ShaderSettings_Tier2:
     useCascadedShadowMaps: 1
     standardShaderQuality: 2

--- a/ProjectSettings/GraphicsSettings.asset
+++ b/ProjectSettings/GraphicsSettings.asset
@@ -39,10 +39,10 @@ GraphicsSettings:
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}
   m_ShaderSettings_Tier1:
-    useCascadedShadowMaps: 0
-    standardShaderQuality: 0
-    useReflectionProbeBoxProjection: 0
-    useReflectionProbeBlending: 0
+    useCascadedShadowMaps: 1
+    standardShaderQuality: 2
+    useReflectionProbeBoxProjection: 1
+    useReflectionProbeBlending: 1
   m_ShaderSettings_Tier2:
     useCascadedShadowMaps: 1
     standardShaderQuality: 2


### PR DESCRIPTION
In some cases text scales too small using FixedAngularSize. Though the overall size stays visually the same based on the FOV, the content can scale too much when getting closer to UI elements.

I added an override value that will reduce or increase the scale ratio as needed. By default it will act exactly the same as it does now, but if there is a UI element with content scaling too small, the override size ratio can be used to reduce the amount of scale as the user get closer to the element. This new value takes the original scale ratio and treats it like a lever using the starting position as the fulcrum. The override scale ratio moves this lever up or down to adjust the scale ratio (or angular ratio) so that the UI content is always legible.
