### PR TITLE
Sharing fixes

### DIFF
--- a/Assets/HoloToolkit/Sharing/Scripts/SharingStage.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/SharingStage.cs
@@ -62,7 +62,15 @@ namespace HoloToolkit.Sharing
             {
                 AutoDiscoverInit();
             }
-            else
+            //else
+            //{
+            //    Connect(); //call this from start, when init is done
+            //}
+        }
+
+        private void Start()
+        {
+            if (!AutoDiscoverServer)
             {
                 Connect();
             }
@@ -134,7 +142,11 @@ namespace HoloToolkit.Sharing
             this.sharingMgr = SharingManager.Create(config);
 
             //delay sending notification so everything is initialized properly
-            Invoke("SendConnectedNotification", 1);
+            //Invoke("SendConnectedNotification", 1);
+
+            //since Create seems like a blocking call, we should be able to call SendConnectedNotification
+            //from Start() when all events are set up within Awake()
+            SendConnectedNotification();
         }
 
         private void SendConnectedNotification()

--- a/Assets/HoloToolkit/Sharing/Scripts/SharingStage.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/SharingStage.cs
@@ -160,9 +160,6 @@ namespace HoloToolkit.Sharing
             this.networkConnectionAdapter = new NetworkConnectionAdapter();
             networkConnectionAdapter.ConnectedCallback += NetworkConnectionAdapter_ConnectedCallback;
             networkConnection.AddListener((byte)MessageID.StatusOnly, networkConnectionAdapter);
-
-            //delay sending notification so everything is initialized properly
-            //Invoke("SendConnectedNotification", 1);
         }
 
         private void NetworkConnectionAdapter_ConnectedCallback(NetworkConnection obj)

--- a/Assets/HoloToolkit/Sharing/Scripts/SharingStage.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/SharingStage.cs
@@ -80,7 +80,6 @@ namespace HoloToolkit.Sharing
 
         protected void OnDestroy()
         {
-
             if (this.discoveryClient != null)
             {
                 discoveryClient.RemoveListener(discoveryClientAdapter);

--- a/Assets/HoloToolkit/Sharing/Scripts/SharingStage.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/SharingStage.cs
@@ -48,7 +48,11 @@ namespace HoloToolkit.Sharing
         /// </summary>
         private DiscoveryClientAdapter discoveryClientAdapter;
 
+        /// <summary>
+        /// Provides callbacks for when we connect to a server.
+        /// </summary>
         private NetworkConnectionAdapter networkConnectionAdapter = null;
+
         private NetworkConnection networkConnection = null;
     
         private float pingIntervalCurrent = 0;
@@ -56,7 +60,6 @@ namespace HoloToolkit.Sharing
 
         private void Awake()
         {
-            Debug.Log("SharingStage Awake");
             this.logWriter = new ConsoleLogWriter();
 
             if (AutoDiscoverServer)
@@ -151,13 +154,12 @@ namespace HoloToolkit.Sharing
             config.SetProfilerEnabled(false);
 
             this.sharingMgr = SharingManager.Create(config);
+
+            //set up callbacks so that we know when we've connected successfully
             this.networkConnection = sharingMgr.GetServerConnection();
             this.networkConnectionAdapter = new NetworkConnectionAdapter();
-            
             networkConnectionAdapter.ConnectedCallback += NetworkConnectionAdapter_ConnectedCallback;
             networkConnection.AddListener((byte)MessageID.StatusOnly, networkConnectionAdapter);
-
-            Debug.Log("SharingManager.Create returned " + sharingMgr.ToString());
 
             //delay sending notification so everything is initialized properly
             //Invoke("SendConnectedNotification", 1);
@@ -165,7 +167,6 @@ namespace HoloToolkit.Sharing
 
         private void NetworkConnectionAdapter_ConnectedCallback(NetworkConnection obj)
         {
-            Debug.Log("Got ConnectedCallback, calling SendConnectedNotification");
             SendConnectedNotification();
         }
 

--- a/Assets/HoloToolkit/Sharing/Scripts/SharingStage.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/SharingStage.cs
@@ -1,16 +1,15 @@
-﻿using System;
+﻿using HoloToolkit.Unity;
+using System;
 using UnityEngine;
 
 namespace HoloToolkit.Sharing
 {
-    public class SharingStage : MonoBehaviour
+    public class SharingStage : Singleton<SharingStage>
     {
         /// <summary>
         /// SharingManagerConnected event notifies when the sharing manager is created and connected.
         /// </summary>
         public event EventHandler SharingManagerConnected;
-
-        public static SharingStage Instance = null;
 
         /// <summary>
         /// Set whether this app should be a Primary or Secondary client.
@@ -54,7 +53,6 @@ namespace HoloToolkit.Sharing
 
         private void Awake()
         {
-            Instance = this;
 
             this.logWriter = new ConsoleLogWriter();
 
@@ -62,10 +60,6 @@ namespace HoloToolkit.Sharing
             {
                 AutoDiscoverInit();
             }
-            //else
-            //{
-            //    Connect(); //call this from start, when init is done
-            //}
         }
 
         private void Start()
@@ -78,7 +72,6 @@ namespace HoloToolkit.Sharing
 
         protected void OnDestroy()
         {
-            Instance = null;
 
             if (this.discoveryClient != null)
             {
@@ -142,11 +135,7 @@ namespace HoloToolkit.Sharing
             this.sharingMgr = SharingManager.Create(config);
 
             //delay sending notification so everything is initialized properly
-            //Invoke("SendConnectedNotification", 1);
-
-            //since Create seems like a blocking call, we should be able to call SendConnectedNotification
-            //from Start() when all events are set up within Awake()
-            SendConnectedNotification();
+            Invoke("SendConnectedNotification", 1);
         }
 
         private void SendConnectedNotification()

--- a/Assets/HoloToolkit/Sharing/Tests/ImportExportAnchorManager.cs
+++ b/Assets/HoloToolkit/Sharing/Tests/ImportExportAnchorManager.cs
@@ -133,6 +133,11 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
 
     void OnDestroy()
     {
+        if (SharingStage.Instance != null)
+        {
+            SharingStage.Instance.SharingManagerConnected -= SharingManagerConnected;
+        }
+
         if (roomManagerCallbacks != null)
         {
             roomManagerCallbacks.AnchorsDownloadedEvent -= RoomManagerCallbacks_AnchorsDownloaded;

--- a/Assets/HoloToolkit/Sharing/Tests/ImportExportAnchorManager.cs
+++ b/Assets/HoloToolkit/Sharing/Tests/ImportExportAnchorManager.cs
@@ -128,6 +128,10 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
 
         //Wait for a notification that the sharing manager has been initialized (connected to sever)
         SharingStage.Instance.SharingManagerConnected += SharingManagerConnected;
+
+        // We will register for session joined to indicate when the sharing service
+        // is ready for us to make room related requests.
+        SharingSessionTracker.Instance.SessionJoined += Instance_SessionJoined;
     }
 
     void OnDestroy()
@@ -153,10 +157,6 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
         roomManagerCallbacks.AnchorsDownloadedEvent += RoomManagerCallbacks_AnchorsDownloaded;
         roomManagerCallbacks.AnchorUploadedEvent += RoomManagerCallbacks_AnchorUploaded;
         roomManager.AddListener(roomManagerCallbacks);
-
-        // We will register for session joined to indicate when the sharing service
-        // is ready for us to make room related requests.
-        SharingSessionTracker.Instance.SessionJoined += Instance_SessionJoined;
     }
 
     /// <summary>

--- a/Assets/HoloToolkit/Sharing/Tests/ImportExportAnchorManager.cs
+++ b/Assets/HoloToolkit/Sharing/Tests/ImportExportAnchorManager.cs
@@ -18,7 +18,7 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
     /// <summary>
     /// Enum to track the progress through establishing a shared coordinate system.
     /// </summary>
-    enum ImportExportState
+    private enum ImportExportState
     {
         // Overall states
         Start,
@@ -39,7 +39,7 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
         Importing
     }
 
-    ImportExportState currentState = ImportExportState.Start;
+    private ImportExportState currentState = ImportExportState.Start;
 
     public string StateName
     {

--- a/Assets/HoloToolkit/Sharing/Tests/ImportExportAnchorManager.cs
+++ b/Assets/HoloToolkit/Sharing/Tests/ImportExportAnchorManager.cs
@@ -41,7 +41,7 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
 
     ImportExportState currentState = ImportExportState.Start;
 
-    public string StateName
+    private string StateName
     {
         get
         {
@@ -49,7 +49,7 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
         }
     }
 
-    public bool AnchorEstablished
+    private bool AnchorEstablished
     {
         get
         {
@@ -60,69 +60,72 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
     /// <summary>
     /// WorldAnchorTransferBatch is the primary object in serializing/deserializing anchors.
     /// </summary>
-    WorldAnchorTransferBatch sharedAnchorInterface;
+    private WorldAnchorTransferBatch sharedAnchorInterface;
 
     /// <summary>
     /// Keeps track of stored anchor data blob.
     /// </summary>
-    byte[] rawAnchorData = null;
+    private byte[] rawAnchorData = null;
 
     /// <summary>
     /// Keeps track of locally stored anchors.
     /// </summary>
-    WorldAnchorStore anchorStore = null;
+    private WorldAnchorStore anchorStore = null;
 
     /// <summary>
     /// Keeps track of the name of the anchor we are exporting.
     /// </summary>
-    string exportingAnchorName { get; set; }
+    private string exportingAnchorName { get; set; }
 
     /// <summary>
     /// The datablob of the anchor.
     /// </summary>
-    List<byte> exportingAnchorBytes = new List<byte>();
+    private List<byte> exportingAnchorBytes = new List<byte>();
 
     /// <summary>
     /// Keeps track of if the sharing service is ready.
     /// We need the sharing service to be ready so we can
     /// upload and download data for sharing anchors.
     /// </summary>
-    bool sharingServiceReady = false;
+    private bool sharingServiceReady = false;
 
     /// <summary>
     /// The room manager API for the sharing service.
     /// </summary>
-    RoomManager roomManager;
+    private RoomManager roomManager;
 
     /// <summary>
     /// Keeps track of the current room we are connected to.  Anchors
     /// are kept in rooms.
     /// </summary>
-    Room currentRoom;
+    private Room currentRoom;
 
     /// <summary>
     /// Sometimes we'll see a really small anchor blob get generated.
     /// These tend to not work, so we have a minimum trustable size.
     /// </summary>
-    const uint minTrustworthySerializedAnchorDataSize = 100000;
+    private const uint minTrustworthySerializedAnchorDataSize = 100000;
 
     /// <summary>
     /// Some room ID for indicating which room we are in.
     /// </summary>
-    const long roomID = 8675309;
+    private const long roomID = 8675309;
 
     /// <summary>
     /// Provides updates when anchor data is uploaded/downloaded.
     /// </summary>
-    RoomManagerAdapter roomManagerCallbacks;
+    private RoomManagerAdapter roomManagerCallbacks;
 
-    void Awake()
+    private void Awake()
     {
         Debug.Log("Import Export Manager starting");
         // We need to get our local anchor store started up.
         currentState = ImportExportState.AnchorStore_Initializing;
         WorldAnchorStore.GetAsync(AnchorStoreReady);
+    }
 
+    private void Start()
+    {
         //Wait for a notification that the sharing manager has been initialized (connected to sever)
         SharingStage.Instance.SharingManagerConnected += SharingManagerConnected;
 
@@ -131,7 +134,7 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
         SharingSessionTracker.Instance.SessionJoined += Instance_SessionJoined;
     }
 
-    void OnDestroy()
+    private void OnDestroy()
     {
         if (SharingStage.Instance != null)
         {
@@ -204,7 +207,7 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
     /// Called when the local anchor store is ready.
     /// </summary>
     /// <param name="store"></param>
-    void AnchorStoreReady(WorldAnchorStore store)
+    private void AnchorStoreReady(WorldAnchorStore store)
     {
         anchorStore = store;
         currentState = ImportExportState.AnchorStore_Initialized;
@@ -226,7 +229,7 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
         Invoke("MarkSharingServiceReady", 5);
     }
 
-    void MarkSharingServiceReady()
+    private void MarkSharingServiceReady()
     {
         sharingServiceReady = true;
     }
@@ -234,7 +237,7 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
     /// <summary>
     /// Initializes the room api.
     /// </summary>
-    void InitRoomApi()
+    private void InitRoomApi()
     {
         // If we have a room, we'll join the first room we see.
         // If we are the user with the lowest user ID, we will create the room.
@@ -264,7 +267,7 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
         }
     }
 
-    bool LocalUserHasLowestUserId()
+    private bool LocalUserHasLowestUserId()
     {
         long localUserId = CustomMessages.Instance.localUserID;
         foreach (long userid in SharingSessionTracker.Instance.UserIds)
@@ -281,7 +284,7 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
     /// <summary>
     /// Kicks off the process of creating the shared space.
     /// </summary>
-    void StartAnchorProcess()
+    private void StartAnchorProcess()
     {
         // First, are there any anchors in this room?
         int anchorCount = currentRoom.GetAnchorCount();
@@ -308,7 +311,7 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
     /// <summary>
     /// Kicks off getting the datablob required to import the shared anchor.
     /// </summary>
-    void MakeAnchorDataRequest()
+    private void MakeAnchorDataRequest()
     {
         if (roomManager.DownloadAnchor(currentRoom, currentRoom.GetAnchorName(0)))
         {
@@ -321,7 +324,7 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
         }
     }
 
-    void Update()
+    private void Update()
     {
         switch (currentState)
         {
@@ -355,7 +358,7 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
     /// <summary>
     /// Starts establishing a new anchor.
     /// </summary>
-    void CreateAnchorLocally()
+    private void CreateAnchorLocally()
     {
         WorldAnchor anchor = GetComponent<WorldAnchor>();
         if (anchor == null)
@@ -396,7 +399,7 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
     /// Attempts to attach to  an anchor by anchorName in the local store..
     /// </summary>
     /// <returns>True if it attached, false if it could not attach</returns>
-    bool AttachToCachedAnchor(string AnchorName)
+    private bool AttachToCachedAnchor(string AnchorName)
     {
         Debug.Log("Looking for " + AnchorName);
         string[] ids = anchorStore.GetAllIds();
@@ -448,7 +451,7 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
     /// </summary>
     /// <param name="status"></param>
     /// <param name="wat"></param>
-    void ImportComplete(SerializationCompletionReason status, WorldAnchorTransferBatch wat)
+    private void ImportComplete(SerializationCompletionReason status, WorldAnchorTransferBatch wat)
     {
         if (status == SerializationCompletionReason.Succeeded && wat.GetAllIds().Length > 0)
         {
@@ -471,7 +474,7 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
     /// <summary>
     /// Exports the currently created anchor.
     /// </summary>
-    void Export()
+    private void Export()
     {
         WorldAnchor anchor = GetComponent<WorldAnchor>();
 
@@ -502,7 +505,7 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
     /// Called by the WorldAnchorTransferBatch as anchor data is available.
     /// </summary>
     /// <param name="data"></param>
-    public void WriteBuffer(byte[] data)
+    private void WriteBuffer(byte[] data)
     {
         exportingAnchorBytes.AddRange(data);
     }
@@ -511,7 +514,7 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
     /// Called by the WorldAnchorTransferBatch when anchor exporting is complete.
     /// </summary>
     /// <param name="status"></param>
-    public void ExportComplete(SerializationCompletionReason status)
+    private void ExportComplete(SerializationCompletionReason status)
     {
         if (status == SerializationCompletionReason.Succeeded && exportingAnchorBytes.Count > minTrustworthySerializedAnchorDataSize)
         {

--- a/Assets/HoloToolkit/Sharing/Tests/ImportExportAnchorManager.cs
+++ b/Assets/HoloToolkit/Sharing/Tests/ImportExportAnchorManager.cs
@@ -118,6 +118,7 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
 
     void Awake()
     {
+        Debug.Log("ImportExportAnchorManager Awake");
         // We need to get our local anchor store started up.
         currentState = ImportExportState.AnchorStore_Initializing;
         WorldAnchorStore.GetAsync(AnchorStoreReady);
@@ -154,6 +155,7 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
     private void SharingManagerConnected(object sender, EventArgs e)
     {
         // Setup the room manager callbacks.
+        Debug.Log("SharingManagerConnected called");
         roomManager = SharingStage.Instance.Manager.GetRoomManager();
         roomManagerCallbacks = new RoomManagerAdapter();
 

--- a/Assets/HoloToolkit/Sharing/Tests/ImportExportAnchorManager.cs
+++ b/Assets/HoloToolkit/Sharing/Tests/ImportExportAnchorManager.cs
@@ -118,7 +118,7 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
 
     void Awake()
     {
-        Debug.Log("ImportExportAnchorManager Awake");
+        Debug.Log("Import Export Manager starting");
         // We need to get our local anchor store started up.
         currentState = ImportExportState.AnchorStore_Initializing;
         WorldAnchorStore.GetAsync(AnchorStoreReady);
@@ -129,13 +129,6 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
         // We will register for session joined to indicate when the sharing service
         // is ready for us to make room related requests.
         SharingSessionTracker.Instance.SessionJoined += Instance_SessionJoined;
-    }
-
-    void Start()
-    {
-        Debug.Log("Import Export Manager starting");
-
-        //currentState = ImportExportState.Ready;
     }
 
     void OnDestroy()
@@ -155,7 +148,6 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
     private void SharingManagerConnected(object sender, EventArgs e)
     {
         // Setup the room manager callbacks.
-        Debug.Log("SharingManagerConnected called");
         roomManager = SharingStage.Instance.Manager.GetRoomManager();
         roomManagerCallbacks = new RoomManagerAdapter();
 

--- a/Assets/HoloToolkit/Sharing/Tests/ImportExportAnchorManager.cs
+++ b/Assets/HoloToolkit/Sharing/Tests/ImportExportAnchorManager.cs
@@ -41,7 +41,7 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
 
     ImportExportState currentState = ImportExportState.Start;
 
-    private string StateName
+    public string StateName
     {
         get
         {
@@ -49,7 +49,7 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
         }
     }
 
-    private bool AnchorEstablished
+    public bool AnchorEstablished
     {
         get
         {
@@ -505,7 +505,7 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
     /// Called by the WorldAnchorTransferBatch as anchor data is available.
     /// </summary>
     /// <param name="data"></param>
-    private void WriteBuffer(byte[] data)
+    public void WriteBuffer(byte[] data)
     {
         exportingAnchorBytes.AddRange(data);
     }
@@ -514,7 +514,7 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
     /// Called by the WorldAnchorTransferBatch when anchor exporting is complete.
     /// </summary>
     /// <param name="status"></param>
-    private void ExportComplete(SerializationCompletionReason status)
+    public void ExportComplete(SerializationCompletionReason status)
     {
         if (status == SerializationCompletionReason.Succeeded && exportingAnchorBytes.Count > minTrustworthySerializedAnchorDataSize)
         {

--- a/Assets/HoloToolkit/Sharing/Tests/ImportExportAnchorManager.cs
+++ b/Assets/HoloToolkit/Sharing/Tests/ImportExportAnchorManager.cs
@@ -116,12 +116,8 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
     /// </summary>
     RoomManagerAdapter roomManagerCallbacks;
 
-    void Start()
+    void Awake()
     {
-        Debug.Log("Import Export Manager starting");
-
-        currentState = ImportExportState.Ready;
-
         // We need to get our local anchor store started up.
         currentState = ImportExportState.AnchorStore_Initializing;
         WorldAnchorStore.GetAsync(AnchorStoreReady);
@@ -132,6 +128,13 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
         // We will register for session joined to indicate when the sharing service
         // is ready for us to make room related requests.
         SharingSessionTracker.Instance.SessionJoined += Instance_SessionJoined;
+    }
+
+    void Start()
+    {
+        Debug.Log("Import Export Manager starting");
+
+        //currentState = ImportExportState.Ready;
     }
 
     void OnDestroy()


### PR DESCRIPTION
This references issue https://github.com/Microsoft/HoloToolkit-Unity/issues/292

The major fixes here are subscribing to `NetworkConnection` events so that we know when we're connected to the server instead of using `Invoke` with a certain time (which failed when init took more than one second) and using `Singleton<T>` for `SharingStage`, as the previous implementation was broken and an unnecessary duplication of efforts.

My previous testing showed the Sharing sample scene to work now, which wasn't the case before; I would appreciate if some other people tested and verified this to be true.
