### PR TITLE
Sharing Test script update.

### DIFF
--- a/Assets/HoloToolkit/Sharing/Tests/ImportExportAnchorManager.cs
+++ b/Assets/HoloToolkit/Sharing/Tests/ImportExportAnchorManager.cs
@@ -232,6 +232,10 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
     private void MarkSharingServiceReady()
     {
         sharingServiceReady = true;
+
+#if UNITY_EDITOR
+        InitRoomApi();
+#endif
     }
 
     /// <summary>


### PR DESCRIPTION
Enables ImportExportAnchorManager to place user into a room if testing in editor.
Also helps fix https://github.com/Microsoft/HoloToolkit-Unity/issues/292 while in editor.