### PR TITLE
Force Text Asset Serialization and visible meta files

### DIFF
--- a/Assets/HoloToolkit/Utilities/Editor/EnforceEditorSettings.cs
+++ b/Assets/HoloToolkit/Utilities/Editor/EnforceEditorSettings.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEditor;
+
+namespace HoloToolKit.Unity
+{
+    [InitializeOnLoad]
+    public class EnforceEditorSettings
+    {
+        static EnforceEditorSettings()
+        {
+            #region Editor Settings
+
+            if (EditorSettings.serializationMode != SerializationMode.ForceText)
+            {
+                EditorSettings.serializationMode = SerializationMode.ForceText;
+                UnityEngine.Debug.Log("Setting Force Text Serialization");
+            }
+
+            if (!EditorSettings.externalVersionControl.Equals("Visible Meta Files"))
+            {
+                EditorSettings.externalVersionControl = "Visible Meta Files";
+                UnityEngine.Debug.Log("Updated external version control mode: " + EditorSettings.externalVersionControl);
+            }
+
+            #endregion
+        }
+    }
+}

--- a/Assets/HoloToolkit/Utilities/Editor/EnforceEditorSettings.cs.meta
+++ b/Assets/HoloToolkit/Utilities/Editor/EnforceEditorSettings.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 3d5c88d150a2b95459b4ac57c7e33d00
+timeCreated: 1480429807
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
@jwittner I don't know why this isn't the default settings in Unity.