### PR TITLE
Fix namespace error on HeadsUpDirectionIndicator

### DIFF
--- a/Assets/HoloToolkit/Utilities/Scripts/HeadsUpDirectionIndicator.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/HeadsUpDirectionIndicator.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-namespace HoloToolKit.Unity
+namespace HoloToolkit.Unity
 {
     // The easiest way to use this script is to drop in the HeadsUpDirectionIndicator prefab
     // from the HoloToolKit. If you're having issues with the prefab or can't find it,


### PR DESCRIPTION
#355 

Change the bad namespace to the standard one