### PR TITLE
Fix KeywordManager not stopping when deactivated

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Voice/KeywordManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Voice/KeywordManager.cs
@@ -84,6 +84,22 @@ namespace HoloToolkit.Unity.InputModule
             }
         }
 
+        void OnDisable()
+        {
+            if (keywordRecognizer != null)
+            {
+                StopKeywordRecognizer();
+            }
+        }
+
+        void OnEnable()
+        {
+            if (keywordRecognizer != null && RecognizerStart == RecognizerStartBehavior.AutoStart)
+            {
+                StartKeywordRecognizer();
+            }
+        }
+
         private void ProcessKeyBindings()
         {
             foreach (var kvp in KeywordsAndResponses)


### PR DESCRIPTION
This PR fixes the issue with `KeywordManager` keyword recognition not stopping when the script is deactivated. It also checks for the script being re-enabled and if `RecognizerStart` is set to `RecognizerStartBehavior.AutoStart`, resumes keyword recognition.