### PR TITLE
Add a check to only process key bindings if the recognizer is listening

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Voice/KeywordManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Voice/KeywordManager.cs
@@ -71,7 +71,10 @@ namespace HoloToolkit.Unity.InputModule
 
         void Update()
         {
-            ProcessKeyBindings();
+            if (keywordRecognizer.IsRunning)
+            {
+                ProcessKeyBindings();
+            }
         }
 
         void OnDestroy()


### PR DESCRIPTION
This way, the actions are only performed if they'd be in context for the recognizer too.