### PR TITLE
Fix object orientation being rotated 180 degrees

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Interactions/HandDraggable.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Interactions/HandDraggable.cs
@@ -192,7 +192,7 @@ namespace HoloToolkit.Unity.InputModule
 
             if (IsOrientTowardsUser)
             {
-                draggingRotation = Quaternion.LookRotation(pivotPosition - HostTransform.position);
+                draggingRotation = Quaternion.LookRotation(HostTransform.position - pivotPosition);
             }
             else
             {


### PR DESCRIPTION
When using "Oriented towards user" mode, there was a bug that the object is rotated not towards the user, but exactly from the user.
Reversing the subtraction solves this problem.