### PR TITLE
fix(stereo) allowing shaders to work with singlepass

### DIFF
--- a/Assets/HoloToolkit/Input/Shaders/Cursor.shader
+++ b/Assets/HoloToolkit/Input/Shaders/Cursor.shader
@@ -8,7 +8,7 @@
 	{
 		Tags { "RenderType"="Opaque" }
 		LOD 100
-        ZTest Always
+		ZTest Always
 
 		Pass
 		{
@@ -21,25 +21,31 @@
 			struct appdata
 			{
 				float4 vertex : POSITION;
+				UNITY_VERTEX_INPUT_INSTANCE_ID
 			};
 
 			struct v2f
 			{
 				float4 vertex : SV_POSITION;
+				UNITY_VERTEX_OUTPUT_STEREO
 			};
 
 			float4 _Color;
 			
 			v2f vert (appdata v)
 			{
+				UNITY_SETUP_INSTANCE_ID(v);
+
 				v2f o;
 				o.vertex = mul(UNITY_MATRIX_MVP, v.vertex);
+
+				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
 				return o;
 			}
 			
 			fixed4 frag (v2f i) : SV_Target
 			{
-                fixed4 col = _Color;
+				fixed4 col = _Color;
 				return col;
 			}
 			ENDCG

--- a/Assets/HoloToolkit/Input/Shaders/CursorShader.shader
+++ b/Assets/HoloToolkit/Input/Shaders/CursorShader.shader
@@ -53,6 +53,7 @@ Shader "HoloToolkit/Cursor"
 				float4 vertex   : POSITION;
 				float4 color    : COLOR;
 				float2 texcoord : TEXCOORD0;
+				UNITY_VERTEX_INPUT_INSTANCE_ID
 			};
 
 			struct v2f
@@ -60,12 +61,15 @@ Shader "HoloToolkit/Cursor"
 				float4 vertex   : SV_POSITION;
 				fixed4 color    : COLOR;
 				half2 texcoord  : TEXCOORD0;
+				UNITY_VERTEX_OUTPUT_STEREO
 			};
 			
 			fixed4 _Color;
 
 			v2f vert(appdata_t IN)
 			{
+				UNITY_SETUP_INSTANCE_ID(IN);
+
 				v2f OUT;
 				OUT.vertex = mul(UNITY_MATRIX_MVP, IN.vertex);
 				OUT.texcoord = IN.texcoord;
@@ -73,6 +77,8 @@ Shader "HoloToolkit/Cursor"
 				OUT.vertex.xy += (_ScreenParams.zw-1.0)*float2(-1,1);
 #endif
 				OUT.color = IN.color * _Color;
+
+				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(OUT);
 				return OUT;
 			}
 

--- a/Assets/HoloToolkit/Input/Shaders/EditorHands.shader
+++ b/Assets/HoloToolkit/Input/Shaders/EditorHands.shader
@@ -53,6 +53,7 @@
 				float4 vertex   : POSITION;
 				float4 color    : COLOR;
 				float2 texcoord : TEXCOORD0;
+				UNITY_VERTEX_INPUT_INSTANCE_ID
 			};
 
 			struct v2f
@@ -60,12 +61,15 @@
 				float4 vertex   : SV_POSITION;
 				fixed4 color    : COLOR;
 				half2 texcoord  : TEXCOORD0;
+				UNITY_VERTEX_OUTPUT_STEREO
 			};
 			
 			fixed4 _Color;
 
 			v2f vert(appdata_t IN)
 			{
+				UNITY_SETUP_INSTANCE_ID(IN);
+
 				v2f OUT;
 				OUT.vertex = mul(UNITY_MATRIX_MVP, IN.vertex);
 				OUT.texcoord = IN.texcoord;
@@ -73,6 +77,8 @@
 				OUT.vertex.xy += (_ScreenParams.zw-1.0)*float2(-1,1);
 #endif
 				OUT.color = IN.color * _Color;
+
+				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(OUT);
 				return OUT;
 			}
 

--- a/Assets/HoloToolkit/SpatialMapping/Shaders/Occlusion.shader
+++ b/Assets/HoloToolkit/SpatialMapping/Shaders/Occlusion.shader
@@ -33,12 +33,15 @@ Shader "HoloToolkit/Occlusion"
             struct v2f
             {
                 float4 pos : SV_POSITION;
+                UNITY_VERTEX_OUTPUT_STEREO
             };
 
             v2f vert(appdata_base v)
             {
+                UNITY_SETUP_INSTANCE_ID(v);
                 v2f o;
                 o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
                 return o;
             }
 

--- a/Assets/HoloToolkit/SpatialMapping/Shaders/Wireframe.shader
+++ b/Assets/HoloToolkit/SpatialMapping/Shaders/Wireframe.shader
@@ -38,12 +38,15 @@ Shader "HoloToolkit/Wireframe"
             struct v2g
             {
                 float4 viewPos : SV_POSITION;
+                UNITY_VERTEX_OUTPUT_STEREO
             };
 
             v2g vert(appdata_base v)
             {
+                UNITY_SETUP_INSTANCE_ID(v);
                 v2g o;
                 o.viewPos = mul(UNITY_MATRIX_MVP, v.vertex);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
                 return o;
             }
 
@@ -54,6 +57,7 @@ Shader "HoloToolkit/Wireframe"
                 float4 viewPos : SV_POSITION;
                 float inverseW : TEXCOORD0;
                 float3 dist : TEXCOORD1;
+                UNITY_VERTEX_OUTPUT_STEREO
             };
 
             [maxvertexcount(3)]
@@ -70,27 +74,26 @@ Shader "HoloToolkit/Wireframe"
                 float2 vector2 = point1 - point0;
                 float area = abs(vector1.x * vector2.y - vector1.y * vector2.x);
 
+                float3 distScale[3];
+                distScale[0] = float3(area / length(vector0), 0, 0);
+                distScale[1] = float3(0, area / length(vector1), 0);
+                distScale[2] = float3(0, 0, area / length(vector2));
+
                 float wireScale = 800 - _WireThickness;
 
                 // Output each original vertex with its distance to the opposing line defined
                 // by the other two vertices.
-
                 g2f o;
 
-                o.viewPos = i[0].viewPos;
-                o.inverseW = 1.0 / o.viewPos.w;
-                o.dist = float3(area / length(vector0), 0, 0) * o.viewPos.w * wireScale;
-                triStream.Append(o);
-
-                o.viewPos = i[1].viewPos;
-                o.inverseW = 1.0 / o.viewPos.w;
-                o.dist = float3(0, area / length(vector1), 0) * o.viewPos.w * wireScale;
-                triStream.Append(o);
-
-                o.viewPos = i[2].viewPos;
-                o.inverseW = 1.0 / o.viewPos.w;
-                o.dist = float3(0, 0, area / length(vector2)) * o.viewPos.w * wireScale;
-                triStream.Append(o);
+                [unroll]
+                for (uint idx = 0; idx < 3; ++idx)
+                {
+                   o.viewPos = i[idx].viewPos;
+                   o.inverseW = 1.0 / o.viewPos.w;
+                   o.dist = distScale[idx] * o.viewPos.w * wireScale;
+                   UNITY_TRANSFER_VERTEX_OUTPUT_STEREO(i[idx], o);
+                   triStream.Append(o);
+                }
             }
 
             float4 frag(g2f i) : COLOR

--- a/Assets/HoloToolkit/SpatialUnderstanding/Materials/SpatialUnderstandingSurface.shader
+++ b/Assets/HoloToolkit/SpatialUnderstanding/Materials/SpatialUnderstandingSurface.shader
@@ -4,116 +4,120 @@
 
 Shader "HoloToolkit/SpatialUnderstanding/Understanding"
 {
-    Properties 
-	{
-        _BaseColor ("Base color", Color) = (0.0, 0.0, 0.0, 1.0)
-		_WireColor("Wire color", Color) = (1.0, 1.0, 1.0, 1.0)
-		_Falloff_Scale ("Fall off scale", Range (0, 1)) = 0.5
-		_Falloff_Dst_Min ("Fall off dst min", Range(0, 15)) = 2.0
-		_Falloff_Dst_Max("Fall off dst max", Range(0, 15)) = 6.0
-		_WireThickness ("Wire thickness", Range (0, 800)) = 100
-    }
-    SubShader 
-	{
-        Tags { "RenderType"="Opaque" }
+   Properties
+   {
+      _BaseColor("Base color", Color) = (0.0, 0.0, 0.0, 1.0)
+      _WireColor("Wire color", Color) = (1.0, 1.0, 1.0, 1.0)
+      _Falloff_Scale("Fall off scale", Range(0, 1)) = 0.5
+      _Falloff_Dst_Min("Fall off dst min", Range(0, 15)) = 2.0
+      _Falloff_Dst_Max("Fall off dst max", Range(0, 15)) = 6.0
+      _WireThickness("Wire thickness", Range(0, 800)) = 100
+   }
+   SubShader
+   {
+       Tags { "RenderType" = "Opaque" }
 
-        Pass {
-            Offset 50, 100
+       Pass {
+           Offset 50, 100
 
-            CGPROGRAM
+           CGPROGRAM
 
-            #pragma vertex vert
-            #pragma geometry geom
-            #pragma fragment frag
-            #include "UnityCG.cginc"
+           #pragma vertex vert
+           #pragma geometry geom
+           #pragma fragment frag
+           #include "UnityCG.cginc"
 
-            float4 _BaseColor;
-			float4 _WireColor;
-			float _Falloff_Dst_Min;
-			float _Falloff_Dst_Max;
-			float _Falloff_Scale;
-            float _WireThickness;
+           float4 _BaseColor;
+           float4 _WireColor;
+           float _Falloff_Dst_Min;
+           float _Falloff_Dst_Max;
+           float _Falloff_Scale;
+           float _WireThickness;
 
-            // Based on approach described in "Shader-Based Wireframe Drawing", http://cgg-journal.com/2008-2/06/index.html
-            struct v2g 
-			{
-                float4 viewPos : SV_POSITION;
-            };
+           // Based on approach described in "Shader-Based Wireframe Drawing", http://cgg-journal.com/2008-2/06/index.html
+           struct v2g
+           {
+               float4 viewPos : SV_POSITION;
+               UNITY_VERTEX_OUTPUT_STEREO
+           };
 
-            v2g vert(appdata_base v) 
-			{
-                v2g o;
-                o.viewPos = mul(UNITY_MATRIX_MVP, v.vertex);
-                return o;
-            }
+           v2g vert(appdata_base v)
+           {
+               v2g o;
+               UNITY_SETUP_INSTANCE_ID(v);
+               o.viewPos = mul(UNITY_MATRIX_MVP, v.vertex);
+               UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+               return o;
+           }
 
-            // inverseW is to counter-act the effect of perspective-correct interpolation so that the lines look the same thickness
-            // regardless of their depth in the scene.
-            struct g2f {
-                float4 viewPos : SV_POSITION;
-                float inverseW : TEXCOORD0;
-                float3 dist : TEXCOORD1;
-            };
+           // inverseW is to counter-act the effect of perspective-correct interpolation so that the lines look the same thickness
+           // regardless of their depth in the scene.
+           struct g2f {
+               float4 viewPos : SV_POSITION;
+               float inverseW : TEXCOORD0;
+               float3 dist : TEXCOORD1;
+               UNITY_VERTEX_OUTPUT_STEREO
+           };
 
-            [maxvertexcount(3)]
-            void geom(triangle v2g i[3], inout TriangleStream<g2f> triStream)
-			{
-                // Calculate the vectors that define the triangle from the input points.
-                float2 point0 = i[0].viewPos.xy / i[0].viewPos.w;
-                float2 point1 = i[1].viewPos.xy / i[1].viewPos.w;
-                float2 point2 = i[2].viewPos.xy / i[2].viewPos.w;
+           [maxvertexcount(3)]
+           void geom(triangle v2g i[3], inout TriangleStream<g2f> triStream)
+           {
+              // Calculate the vectors that define the triangle from the input points.
+              float2 point0 = i[0].viewPos.xy / i[0].viewPos.w;
+              float2 point1 = i[1].viewPos.xy / i[1].viewPos.w;
+              float2 point2 = i[2].viewPos.xy / i[2].viewPos.w;
 
-                // Calculate the area of the triangle.
-                float2 vector0 = point2 - point1;
-                float2 vector1 = point2 - point0;
-                float2 vector2 = point1 - point0;
-                float area = abs(vector1.x * vector2.y - vector1.y * vector2.x);
+              // Calculate the area of the triangle.
+              float2 vector0 = point2 - point1;
+              float2 vector1 = point2 - point0;
+              float2 vector2 = point1 - point0;
+              float area = abs(vector1.x * vector2.y - vector1.y * vector2.x);
 
-                float wireScale = 800 - _WireThickness;
+              float3 distScale[3];
+              distScale[0] = float3(area / length(vector0), 0, 0);
+              distScale[1] = float3(0, area / length(vector1), 0);
+              distScale[2] = float3(0, 0, area / length(vector2));
 
-                // Output each original vertex with its distance to the opposing line defined
-                // by the other two vertices.
-                g2f o;
+              float wireScale = 800 - _WireThickness;
 
-                o.viewPos = i[0].viewPos;
-                o.inverseW = 1.0 / o.viewPos.w;
-                o.dist = float3(area / length(vector0), 0, 0) * o.viewPos.w * wireScale;
-                triStream.Append(o);
+              // Output each original vertex with its distance to the opposing line defined
+              // by the other two vertices.
+              g2f o;
 
-                o.viewPos = i[1].viewPos;
-                o.inverseW = 1.0 / o.viewPos.w;
-                o.dist = float3(0, area / length(vector1), 0) * o.viewPos.w * wireScale;
-                triStream.Append(o);
+              [unroll]
+              for (uint idx = 0; idx < 3; ++idx)
+              {
+                  o.viewPos = i[idx].viewPos;
+                  o.inverseW = 1.0 / o.viewPos.w;
+                  o.dist = distScale[idx] * o.viewPos.w * wireScale;
+                  UNITY_TRANSFER_VERTEX_OUTPUT_STEREO(i[idx], o);
+                  triStream.Append(o);
+              }
+          }
 
-                o.viewPos = i[2].viewPos;
-                o.inverseW = 1.0 / o.viewPos.w;
-                o.dist = float3(0, 0, area / length(vector2)) * o.viewPos.w * wireScale;
-                triStream.Append(o);
-            }
+          float4 frag(g2f i) : COLOR
+          {
+             // Calculate  minimum distance to one of the triangle lines, making sure to correct
+             // for perspective-correct interpolation.
+             float dist = min(i.dist[0], min(i.dist[1], i.dist[2])) * i.inverseW;
 
-            float4 frag(g2f i) : COLOR 
-			{
-                // Calculate  minimum distance to one of the triangle lines, making sure to correct
-                // for perspective-correct interpolation.
-                float dist = min(i.dist[0], min(i.dist[1], i.dist[2])) * i.inverseW;
+             // Make the intensity of the line very bright along the triangle edges but fall-off very
+             // quickly.
+             float I = exp2(-2 * dist * dist);
 
-                // Make the intensity of the line very bright along the triangle edges but fall-off very
-                // quickly.
-                float I = exp2(-2 * dist * dist);
+             // Calculate the color fade by distance
+             float fadeByDist = max(((_Falloff_Dst_Max - ((1 / i.inverseW) + _Falloff_Dst_Min)) / (_Falloff_Dst_Max - _Falloff_Dst_Min)), 0);
 
-				// Calculate the color fade by distance
-				float fadeByDist = max(((_Falloff_Dst_Max - ((1 / i.inverseW) + _Falloff_Dst_Min)) / (_Falloff_Dst_Max - _Falloff_Dst_Min)), 0);
+             // Fade out the alpha but not the color so we don't get any weird halo effects from
+             // a fade to a different color.
+             float4 color = (I * _WireColor + (1 - I) * _BaseColor) * lerp(_Falloff_Scale, 1, fadeByDist);
+             color.a = I;
 
-                // Fade out the alpha but not the color so we don't get any weird halo effects from
-                // a fade to a different color.
-				float4 color = (I * _WireColor + (1 - I) * _BaseColor) * lerp(_Falloff_Scale, 1, fadeByDist);
-                color.a = I;
+             return color;
+         }
 
-                return color;
-            }
-
-            ENDCG
-        }
-    }
-    FallBack "Diffuse"
+         ENDCG
+      }
+   }
+   FallBack "Diffuse"
 }

--- a/Assets/HoloToolkit/Utilities/Shaders/UnlitConfigurable.cginc
+++ b/Assets/HoloToolkit/Utilities/Shaders/UnlitConfigurable.cginc
@@ -15,6 +15,7 @@ struct appdata_t
     #if _USEMAINTEX_ON
         float2 texcoord : TEXCOORD0;
     #endif
+    UNITY_VERTEX_INPUT_INSTANCE_ID
 };
 
 struct v2f
@@ -27,10 +28,12 @@ struct v2f
     #if _NEAR_PLANE_FADE_ON
         float fade : TEXCOORD2;
     #endif
+    UNITY_VERTEX_OUTPUT_STEREO
 };
 
 v2f vert(appdata_t v)
 {
+    UNITY_SETUP_INSTANCE_ID(v);
     v2f o;
     o.vertex = mul(UNITY_MATRIX_MVP, v.vertex);
 
@@ -43,6 +46,7 @@ v2f vert(appdata_t v)
     #endif
 
     UNITY_TRANSFER_FOG(o, o.vertex);
+    UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
     return o;
 }
 

--- a/Assets/HoloToolkit/Utilities/Shaders/UnlitNoDepthTest.shader
+++ b/Assets/HoloToolkit/Utilities/Shaders/UnlitNoDepthTest.shader
@@ -2,7 +2,7 @@
 {
 	Properties
 	{
-		_MainTex ("Texture", 2D) = "white" {}
+		_MainTex("Texture", 2D) = "white" {}
 	}
 	SubShader
 	{
@@ -11,8 +11,8 @@
 
 		Pass
 		{
-            ZTest Always
-            Blend SrcAlpha OneMinusSrcAlpha
+			ZTest Always
+			Blend SrcAlpha OneMinusSrcAlpha
 			CGPROGRAM
 			#pragma vertex vert
 			#pragma fragment frag
@@ -23,26 +23,30 @@
 			{
 				float4 vertex : POSITION;
 				float2 uv : TEXCOORD0;
+				UNITY_VERTEX_INPUT_INSTANCE_ID
 			};
 
 			struct v2f
 			{
 				float2 uv : TEXCOORD0;
 				float4 vertex : SV_POSITION;
+				UNITY_VERTEX_OUTPUT_STEREO
 			};
 
 			sampler2D _MainTex;
 			float4 _MainTex_ST;
-			
-			v2f vert (appdata v)
+
+			v2f vert(appdata v)
 			{
+				UNITY_SETUP_INSTANCE_ID(v);
 				v2f o;
 				o.vertex = mul(UNITY_MATRIX_MVP, v.vertex);
 				o.uv = v.uv;
+				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
 				return o;
 			}
-			
-			fixed4 frag (v2f i) : SV_Target
+
+			fixed4 frag(v2f i) : SV_Target
 			{
 				// sample the texture
 				fixed4 col = tex2D(_MainTex, i.uv);

--- a/Assets/HoloToolkit/Utilities/Shaders/VertexLitConfigurable.cginc
+++ b/Assets/HoloToolkit/Utilities/Shaders/VertexLitConfigurable.cginc
@@ -26,6 +26,7 @@ struct appdata_t
         float2 texcoord : TEXCOORD0;
     #endif
     float3 normal : NORMAL;
+    UNITY_VERTEX_INPUT_INSTANCE_ID
 };
 
 struct v2f_surf
@@ -44,6 +45,7 @@ struct v2f_surf
     #if _NEAR_PLANE_FADE_ON
         float fade : TEXCOORD5;
     #endif
+    UNITY_VERTEX_OUTPUT_STEREO
 };
 
 inline float3 LightingLambertVS(float3 normal, float3 lightDir)
@@ -54,6 +56,7 @@ inline float3 LightingLambertVS(float3 normal, float3 lightDir)
 
 v2f_surf vert(appdata_t v)
 {
+    UNITY_SETUP_INSTANCE_ID(v);
     v2f_surf o;
     UNITY_INITIALIZE_OUTPUT(v2f_surf, o);
 
@@ -77,6 +80,7 @@ v2f_surf vert(appdata_t v)
 
     TRANSFER_VERTEX_TO_FRAGMENT(o);
     UNITY_TRANSFER_FOG(o, o.pos);
+    UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
     return o;
 }
 

--- a/Assets/HoloToolkit/Utilities/Shaders/WindowOcclusion.shader
+++ b/Assets/HoloToolkit/Utilities/Shaders/WindowOcclusion.shader
@@ -32,12 +32,15 @@ Shader "HoloToolkit/WindowOcclusion"
             struct v2f
             {
                 float4 pos : SV_POSITION;
+                UNITY_VERTEX_OUTPUT_STEREO
             };
 
             v2f vert(appdata_base v)
             {
+                UNITY_SETUP_INSTANCE_ID(v);
                 v2f o;
                 o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
                 return o;
             }
 


### PR DESCRIPTION
Many of the holotoolkit shaders weren't working correctly with the
single-pass stereo instancing option enabled in unity 5.5. This change
adds the instanceId and sets up the rendertarget index as required.

See issue #390