### PR TITLE
fix(nearplanefade) multi_compile _NearPlaneFadeOn

### DIFF
--- a/Assets/HoloToolkit/Utilities/Shaders/BlinnPhongConfigurable.shader
+++ b/Assets/HoloToolkit/Utilities/Shaders/BlinnPhongConfigurable.shader
@@ -68,7 +68,7 @@ Shader "HoloToolkit/BlinnPhong Configurable"
         #pragma shader_feature _USEMAINTEX_ON
         #pragma shader_feature _USEBUMPMAP_ON
         #pragma shader_feature _USEEMISSIONTEX_ON
-        #pragma shader_feature _NEAR_PLANE_FADE_ON
+        #pragma multi_compile  __ _NEAR_PLANE_FADE_ON
 
         #include "HoloToolkitCommon.cginc"
         #include "BlinnPhongConfigurable.cginc"

--- a/Assets/HoloToolkit/Utilities/Shaders/BlinnPhongConfigurableTransparent.shader
+++ b/Assets/HoloToolkit/Utilities/Shaders/BlinnPhongConfigurableTransparent.shader
@@ -68,7 +68,7 @@ Shader "HoloToolkit/BlinnPhong Configurable Transparent"
         #pragma shader_feature _USEMAINTEX_ON
         #pragma shader_feature _USEBUMPMAP_ON
         #pragma shader_feature _USEEMISSIONTEX_ON
-        #pragma shader_feature _NEAR_PLANE_FADE_ON
+        #pragma multi_compile  __ _NEAR_PLANE_FADE_ON
 
         #include "HoloToolkitCommon.cginc"
         #include "BlinnPhongConfigurable.cginc"

--- a/Assets/HoloToolkit/Utilities/Shaders/LambertianConfigurable.shader
+++ b/Assets/HoloToolkit/Utilities/Shaders/LambertianConfigurable.shader
@@ -61,7 +61,7 @@ Shader "HoloToolkit/Lambertian Configurable"
         #pragma shader_feature _USEMAINTEX_ON
         #pragma shader_feature _USEBUMPMAP_ON
         #pragma shader_feature _USEEMISSIONTEX_ON
-        #pragma shader_feature _NEAR_PLANE_FADE_ON
+        #pragma multi_compile  __ _NEAR_PLANE_FADE_ON
 
         #include "HoloToolkitCommon.cginc"
         #include "LambertianConfigurable.cginc"

--- a/Assets/HoloToolkit/Utilities/Shaders/LambertianConfigurableTransparent.shader
+++ b/Assets/HoloToolkit/Utilities/Shaders/LambertianConfigurableTransparent.shader
@@ -61,7 +61,7 @@ Shader "HoloToolkit/Lambertian Configurable Transparent"
         #pragma shader_feature _USEMAINTEX_ON
         #pragma shader_feature _USEBUMPMAP_ON
         #pragma shader_feature _USEEMISSIONTEX_ON
-        #pragma shader_feature _NEAR_PLANE_FADE_ON
+        #pragma multi_compile  __ _NEAR_PLANE_FADE_ON
 
         #include "HoloToolkitCommon.cginc"
         #include "LambertianConfigurable.cginc"

--- a/Assets/HoloToolkit/Utilities/Shaders/UnlitConfigurable.shader
+++ b/Assets/HoloToolkit/Utilities/Shaders/UnlitConfigurable.shader
@@ -55,7 +55,7 @@ Shader "HoloToolkit/Unlit Configurable"
 
             #pragma shader_feature _USECOLOR_ON
             #pragma shader_feature _USEMAINTEX_ON
-            #pragma shader_feature _NEAR_PLANE_FADE_ON
+            #pragma multi_compile  __ _NEAR_PLANE_FADE_ON
 
             #include "HoloToolkitCommon.cginc"
             #include "UnlitConfigurable.cginc"

--- a/Assets/HoloToolkit/Utilities/Shaders/UnlitConfigurableTransparent.shader
+++ b/Assets/HoloToolkit/Utilities/Shaders/UnlitConfigurableTransparent.shader
@@ -55,7 +55,7 @@ Shader "HoloToolkit/Unlit Configurable Transparent"
 
             #pragma shader_feature _USECOLOR_ON
             #pragma shader_feature _USEMAINTEX_ON
-            #pragma shader_feature _NEAR_PLANE_FADE_ON
+            #pragma multi_compile  __ _NEAR_PLANE_FADE_ON
 
             #include "HoloToolkitCommon.cginc"
             #include "UnlitConfigurable.cginc"

--- a/Assets/HoloToolkit/Utilities/Shaders/VertexLitConfigurable.shader
+++ b/Assets/HoloToolkit/Utilities/Shaders/VertexLitConfigurable.shader
@@ -63,7 +63,7 @@ Shader "HoloToolkit/Vertex Lit Configurable"
             #pragma shader_feature _USECOLOR_ON
             #pragma shader_feature _USEMAINTEX_ON
             #pragma shader_feature _USEEMISSIONTEX_ON
-            #pragma shader_feature _NEAR_PLANE_FADE_ON
+            #pragma multi_compile  __ _NEAR_PLANE_FADE_ON
 
             #include "HoloToolkitCommon.cginc"
             #include "VertexLitConfigurable.cginc"

--- a/Assets/HoloToolkit/Utilities/Shaders/VertexLitConfigurableTransparent.shader
+++ b/Assets/HoloToolkit/Utilities/Shaders/VertexLitConfigurableTransparent.shader
@@ -63,7 +63,7 @@ Shader "HoloToolkit/Vertex Lit Configurable Transparent"
             #pragma shader_feature _USECOLOR_ON
             #pragma shader_feature _USEMAINTEX_ON
             #pragma shader_feature _USEEMISSIONTEX_ON
-            #pragma shader_feature _NEAR_PLANE_FADE_ON
+            #pragma multi_compile  __ _NEAR_PLANE_FADE_ON
 
             #include "HoloToolkitCommon.cginc"
             #include "VertexLitConfigurable.cginc"


### PR DESCRIPTION
As mentioned in issue #391 I'm not very familiar with how Unity shaders work under the covers, so I am not 100% sure if this is the correct fix or not. That being said, it produces the correct results.