### PR TITLE
Refactor TapToPlace.cs to be more generic

### DIFF
--- a/Assets/HoloToolkit/SpatialMapping/README.md
+++ b/Assets/HoloToolkit/SpatialMapping/README.md
@@ -58,7 +58,10 @@ Generates and retrieves meshes based on spatial mapping data coming from the cur
 SpatialMappingManager.cs manages switching between source types and interacting with this class.
 
 #### TapToPlace.cs
-Simple script to add to a GameObject that allows users to tap and place the GameObject along the spatial mapping mesh.
+Simple extendable script to add to a GameObject that allows users to tap and place the GameObject along the spatial mapping mesh. 
+
+TapToPlace also allows the user to specify a parent GameObject to move along with the selected GameObject.
+
 Requires GazeManager, GestureManager, and SpatialMappingManager in the scene.
 
 ### [Scripts\RemoteMapping](Scripts/RemoteMapping)

--- a/Assets/HoloToolkit/SpatialMapping/Scripts/TapToPlace.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/TapToPlace.cs
@@ -94,8 +94,8 @@ namespace HoloToolkit.Unity
             if (IsBeingDragged)
             {
                 // Do a raycast into the world that will only hit the Spatial Mapping mesh.
-                var headPosition = Camera.main.transform.position;
-                var gazeDirection = Camera.main.transform.forward;
+                Vector3 headPosition = Camera.main.transform.position;
+                Vector3 gazeDirection = Camera.main.transform.forward;
 
                 RaycastHit hitInfo;
                 if (Physics.Raycast(headPosition, gazeDirection, out hitInfo, 30.0f, spatialMappingManager.LayerMask))

--- a/Assets/HoloToolkit/SpatialMapping/Scripts/TapToPlace.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/TapToPlace.cs
@@ -76,23 +76,30 @@ namespace HoloToolkit.Unity
                 Destroy(this);
             }
 
-            if (PlaceParentOnTap && !gameObject.transform.IsChildOf(ParentGameObjectToPlace.transform))
+            if (PlaceParentOnTap)
             {
-                Debug.LogError("The specified parent object is not a parent of this object.");
-            }
+                if  (ParentGameObjectToPlace != null && !gameObject.transform.IsChildOf(ParentGameObjectToPlace.transform))
+                {
+                    Debug.LogError("The specified parent object is not a parent of this object.");
+                }
 
-            DetermineParent();
+                DetermineParent();
+            }
         }
 
         private void DetermineParent()
         {
-            if (ParentGameObjectToPlace != null)
+            if (ParentGameObjectToPlace == null)
             {
-                objectToPlace = ParentGameObjectToPlace;
-            }
-            else
-            {
-                objectToPlace = gameObject.transform.parent.gameObject;
+                if (gameObject.transform.parent == null)
+                {
+                    Debug.LogError("The selected GameObject has no parent.");
+                    PlaceParentOnTap = false;
+                }
+                else
+                {
+                    ParentGameObjectToPlace = gameObject.transform.parent.gameObject;
+                }
             }
         }
 
@@ -113,7 +120,8 @@ namespace HoloToolkit.Unity
                     // Place the parent object as well but keep the focus on the current game object
                     if (PlaceParentOnTap)
                     {
-                        ParentGameObjectToPlace.transform.position = hitInfo.point - gameObject.transform.localPosition;
+                        Vector3 relativePositionToParent = gameObject.transform.position - ParentGameObjectToPlace.transform.position;
+                        ParentGameObjectToPlace.transform.position = hitInfo.point - relativePositionToParent;
                     }
 
                     // Move this object to where the raycast

--- a/Assets/HoloToolkit/SpatialMapping/Scripts/TapToPlace.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/TapToPlace.cs
@@ -87,9 +87,13 @@ namespace HoloToolkit.Unity
         private void DetermineParent()
         {
             if (ParentGameObjectToPlace != null)
+            {
                 objectToPlace = ParentGameObjectToPlace;
+            }
             else
+            {
                 objectToPlace = gameObject.transform.parent.gameObject;
+            }
         }
 
         public virtual void Update()
@@ -108,7 +112,9 @@ namespace HoloToolkit.Unity
                 {
                     // Place the parent object as well but keep the focus on the current game object
                     if (PlaceParentOnTap)
+                    {
                         ParentGameObjectToPlace.transform.position = hitInfo.point - gameObject.transform.localPosition;
+                    }
 
                     // Move this object to where the raycast
                     // hit the Spatial Mapping mesh.

--- a/Assets/HoloToolkit/SpatialMapping/Scripts/TapToPlace.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/TapToPlace.cs
@@ -50,7 +50,7 @@ namespace HoloToolkit.Unity
         /// Keeps track of the relative position between the parent object to be moved and
         /// the current gameobject this script is attached to.
         /// </summary>
-        private Vector3 ParentPositionRelativeToChild;
+        private Vector3 parentPositionRelativeToChild;
 
         public virtual void Start()
         {
@@ -86,7 +86,7 @@ namespace HoloToolkit.Unity
 
                 DetermineParent();
 
-                ParentPositionRelativeToChild = gameObject.transform.position - ParentGameObjectToPlace.transform.position;
+                parentPositionRelativeToChild = gameObject.transform.position - ParentGameObjectToPlace.transform.position;
             }
         }
 
@@ -118,7 +118,7 @@ namespace HoloToolkit.Unity
                     if (PlaceParentOnTap)
                     {
                         // Place the parent object as well but keep the focus on the current game object
-                        ParentGameObjectToPlace.transform.position = hitInfo.point - ParentPositionRelativeToChild;
+                        ParentGameObjectToPlace.transform.position = hitInfo.point - parentPositionRelativeToChild;
                         ParentGameObjectToPlace.transform.rotation = toQuat;
                     }
                     else

--- a/Assets/HoloToolkit/SpatialMapping/Scripts/TapToPlace.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/TapToPlace.cs
@@ -114,8 +114,7 @@ namespace HoloToolkit.Unity
                 var gazeDirection = Camera.main.transform.forward;
 
                 RaycastHit hitInfo;
-                if (Physics.Raycast(headPosition, gazeDirection, out hitInfo,
-                    30.0f, spatialMappingManager.LayerMask))
+                if (Physics.Raycast(headPosition, gazeDirection, out hitInfo, 30.0f, spatialMappingManager.LayerMask))
                 {
                     // Place the parent object as well but keep the focus on the current game object
                     if (PlaceParentOnTap)

--- a/Assets/HoloToolkit/SpatialMapping/Scripts/TapToPlace.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/TapToPlace.cs
@@ -31,7 +31,7 @@ namespace HoloToolkit.Unity
 
         /// <summary>
         /// Keeps track of if the user is moving the object or not.
-        /// Setting this true will place the object immediately.
+        /// Setting this to true will enable the user to move and place the object in the scene.
         /// </summary>
         public bool IsBeingPlaced;
 

--- a/Assets/HoloToolkit/SpatialMapping/Scripts/TapToPlace.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/TapToPlace.cs
@@ -108,9 +108,7 @@ namespace HoloToolkit.Unity
                 {
                     // Place the parent object as well but keep the focus on the current game object
                     if (PlaceParentOnTap)
-                    {
                         ParentGameObjectToPlace.transform.position = hitInfo.point - gameObject.transform.localPosition;
-                    }
 
                     // Move this object to where the raycast
                     // hit the Spatial Mapping mesh.

--- a/Assets/HoloToolkit/SpatialMapping/Scripts/TapToPlace.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/TapToPlace.cs
@@ -30,6 +30,11 @@ namespace HoloToolkit.Unity
         public GameObject ParentGameObjectToPlace;
 
         /// <summary>
+        /// Keeps track of if the user is moving the object or not.
+        /// </summary>
+        public bool IsBeingDragged;
+
+        /// <summary>
         /// Manages persisted anchors.
         /// </summary>
         private WorldAnchorManager anchorManager;
@@ -39,11 +44,6 @@ namespace HoloToolkit.Unity
         /// to control rendering and to access the physics layer mask.
         /// </summary>
         private SpatialMappingManager spatialMappingManager;
-
-        /// <summary>
-        /// Keeps track of if the user is moving the object or not.
-        /// </summary>
-        private bool placing;
 
         /// <summary>
         /// Keeps track of which object we are placing. By default this is equal to
@@ -87,27 +87,11 @@ namespace HoloToolkit.Unity
             }
         }
 
-        private void DetermineParent()
-        {
-            if (ParentGameObjectToPlace == null)
-            {
-                if (gameObject.transform.parent == null)
-                {
-                    Debug.LogError("The selected GameObject has no parent.");
-                    PlaceParentOnTap = false;
-                }
-                else
-                {
-                    ParentGameObjectToPlace = gameObject.transform.parent.gameObject;
-                }
-            }
-        }
-
         public virtual void Update()
         {
             // If the user is in placing mode,
             // update the placement to match the user's gaze.
-            if (placing)
+            if (IsBeingDragged)
             {
                 // Do a raycast into the world that will only hit the Spatial Mapping mesh.
                 var headPosition = Camera.main.transform.position;
@@ -143,10 +127,10 @@ namespace HoloToolkit.Unity
         public virtual void OnInputClicked(InputEventData eventData)
         {
             // On each tap gesture, toggle whether the user is in placing mode.
-            placing = !placing;
+            IsBeingDragged = !IsBeingDragged;
 
             // If the user is in placing mode, display the spatial mapping mesh.
-            if (placing)
+            if (IsBeingDragged)
             {
                 spatialMappingManager.DrawVisualMeshes = true;
 
@@ -160,6 +144,22 @@ namespace HoloToolkit.Unity
                 spatialMappingManager.DrawVisualMeshes = false;
                 // Add world anchor when object placement is done.
                 anchorManager.AttachAnchor(gameObject, SavedAnchorFriendlyName);
+            }
+        }
+
+        private void DetermineParent()
+        {
+            if (ParentGameObjectToPlace == null)
+            {
+                if (gameObject.transform.parent == null)
+                {
+                    Debug.LogError("The selected GameObject has no parent.");
+                    PlaceParentOnTap = false;
+                }
+                else
+                {
+                    ParentGameObjectToPlace = gameObject.transform.parent.gameObject;
+                }
             }
         }
     }

--- a/Assets/HoloToolkit/SpatialMapping/Scripts/TapToPlace.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/TapToPlace.cs
@@ -31,8 +31,9 @@ namespace HoloToolkit.Unity
 
         /// <summary>
         /// Keeps track of if the user is moving the object or not.
+        /// Setting this true will place the object immediately.
         /// </summary>
-        public bool IsBeingDragged;
+        public bool IsBeingPlaced;
 
         /// <summary>
         /// Manages persisted anchors.
@@ -91,8 +92,9 @@ namespace HoloToolkit.Unity
         {
             // If the user is in placing mode,
             // update the placement to match the user's gaze.
-            if (IsBeingDragged)
+            if (IsBeingPlaced)
             {
+                if (gameObject.GetComponent<TapToPlace>().IsBeingPlaced) { }
                 // Do a raycast into the world that will only hit the Spatial Mapping mesh.
                 Vector3 headPosition = Camera.main.transform.position;
                 Vector3 gazeDirection = Camera.main.transform.forward;
@@ -127,10 +129,10 @@ namespace HoloToolkit.Unity
         public virtual void OnInputClicked(InputEventData eventData)
         {
             // On each tap gesture, toggle whether the user is in placing mode.
-            IsBeingDragged = !IsBeingDragged;
+            IsBeingPlaced = !IsBeingPlaced;
 
             // If the user is in placing mode, display the spatial mapping mesh.
-            if (IsBeingDragged)
+            if (IsBeingPlaced)
             {
                 spatialMappingManager.DrawVisualMeshes = true;
 


### PR DESCRIPTION
#404

This makes the TapToPlace.cs script more generic. Start(), Update(), and OnInputClicked() are now virtual so when it's a base class these methods may be overridden.

Additionally you can now specify a parent to be moved with the currently tapped game object. If no parent is specified then the immediate parent is selected automatically.