### PR TITLE
Fixes material memory leaks in various files

### DIFF
--- a/Assets/HoloToolkit/Input/Tests/Scripts/FocusedObjectColorChanger.cs
+++ b/Assets/HoloToolkit/Input/Tests/Scripts/FocusedObjectColorChanger.cs
@@ -17,7 +17,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
 
         private void Awake()
         {
-            cachedMaterial = GetComponent<Renderer>().sharedMaterial;
+            cachedMaterial = GetComponent<Renderer>().material;
             originalColor = cachedMaterial.GetColor("_Color");
         }
 
@@ -29,6 +29,11 @@ namespace HoloToolkit.Unity.InputModule.Tests
         public void OnFocusExit()
         {
             cachedMaterial.SetColor("_Color", originalColor);
+        }
+
+        private void OnDestroy()
+        {
+            DestroyImmediate(cachedMaterial);
         }
     }
 }

--- a/Assets/HoloToolkit/Input/Tests/Scripts/FocusedObjectColorChanger.cs
+++ b/Assets/HoloToolkit/Input/Tests/Scripts/FocusedObjectColorChanger.cs
@@ -6,27 +6,29 @@ namespace HoloToolkit.Unity.InputModule.Tests
     /// FocusedObjectMessageReceiver class shows how to handle focus events.
     /// This particular implementatoin controls object appearance by changing its color when focused.
     /// </summary>
+    [RequireComponent(typeof(Renderer))]
     public class FocusedObjectColorChanger : MonoBehaviour, IFocusable
     {
-        [Tooltip("Object color changes to this when focused.")] public Color FocusedColor = Color.red;
+        [Tooltip("Object color changes to this when focused.")]
+        public Color FocusedColor = Color.red;
 
-        private Material material;
         private Color originalColor;
+        private Material cachedMaterial;
 
-        private void Start()
+        private void Awake()
         {
-            material = GetComponent<Renderer>().material;
-            originalColor = material.color;
+            cachedMaterial = GetComponent<Renderer>().sharedMaterial;
+            originalColor = cachedMaterial.GetColor("_Color");
         }
 
         public void OnFocusEnter()
         {
-            material.color = FocusedColor;
+            cachedMaterial.SetColor("_Color", FocusedColor);
         }
 
         public void OnFocusExit()
         {
-            material.color = originalColor;
+            cachedMaterial.SetColor("_Color", originalColor);
         }
     }
 }

--- a/Assets/HoloToolkit/Input/Tests/Scripts/SelectedObjectMessageReceiver.cs
+++ b/Assets/HoloToolkit/Input/Tests/Scripts/SelectedObjectMessageReceiver.cs
@@ -17,7 +17,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
 
         private void Awake()
         {
-            cachedMaterial = GetComponent<Renderer>().sharedMaterial;
+            cachedMaterial = GetComponent<Renderer>().material;
             originalColor = cachedMaterial.GetColor("_Color");
         }
 
@@ -29,6 +29,11 @@ namespace HoloToolkit.Unity.InputModule.Tests
         public void OnClearSelection()
         {
             cachedMaterial.SetColor("_Color", originalColor);
+        }
+
+        private void OnDestroy()
+        {
+            DestroyImmediate(cachedMaterial);
         }
     }
 }

--- a/Assets/HoloToolkit/Input/Tests/Scripts/SelectedObjectMessageReceiver.cs
+++ b/Assets/HoloToolkit/Input/Tests/Scripts/SelectedObjectMessageReceiver.cs
@@ -6,27 +6,29 @@ namespace HoloToolkit.Unity.InputModule.Tests
     /// SelectedObjectMessageReceiver class shows how to handle messages sent by SelectedObjectMessageSender.
     /// This particular implementatoin controls object appearance by changing its color when selected.
     /// </summary>
+    [RequireComponent(typeof(Renderer))]
     public class SelectedObjectMessageReceiver : MonoBehaviour
     {
-        [Tooltip("Object color changes to this when selected.")] public Color SelectedColor = Color.red;
+        [Tooltip("Object color changes to this when selected.")]
+        public Color SelectedColor = Color.red;
 
-        private Material material;
         private Color originalColor;
+        private Material cachedMaterial;
 
-        private void Start()
+        private void Awake()
         {
-            material = GetComponent<Renderer>().material;
-            originalColor = material.color;
+            cachedMaterial = GetComponent<Renderer>().sharedMaterial;
+            originalColor = cachedMaterial.GetColor("_Color");
         }
 
         public void OnSelectObject()
         {
-            material.color = SelectedColor;
+            cachedMaterial.SetColor("_Color", SelectedColor);
         }
 
         public void OnClearSelection()
         {
-            material.color = originalColor;
+            cachedMaterial.SetColor("_Color", originalColor);
         }
     }
 }

--- a/Assets/HoloToolkit/Input/Tests/Scripts/SphereGlobalKeywords.cs
+++ b/Assets/HoloToolkit/Input/Tests/Scripts/SphereGlobalKeywords.cs
@@ -1,21 +1,35 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using UnityEngine;
 
 namespace HoloToolkit.Unity.InputModule.Tests
 {
     public class SphereGlobalKeywords : MonoBehaviour, ISpeechHandler
     {
+        private Material[] cachedChildMaterials;
+
+        private void Awake()
+        {
+            Renderer[] childRenderers = GetComponentsInChildren<Renderer>();
+            if (childRenderers != null && childRenderers.Length > 0)
+            {
+                cachedChildMaterials = new Material[childRenderers.Length];
+                for (int i = 0; i < childRenderers.Length; i++)
+                {
+                    cachedChildMaterials[i] = childRenderers[i].sharedMaterial;
+                }
+            }
+        }
+
         public void OnSpeechKeywordRecognized(SpeechKeywordRecognizedEventData eventData)
         {
             switch (eventData.RecognizedText.ToLower())
             {
                 case "reset all":
-                    foreach (Renderer renderer in GetComponentsInChildren<Renderer>())
+                    foreach (Material cachedChildMaterial in cachedChildMaterials)
                     {
-                        renderer.material.color = Color.gray;
+                        cachedChildMaterial.SetColor("_Color", Color.gray);
                     }
                     break;
             }

--- a/Assets/HoloToolkit/Input/Tests/Scripts/SphereGlobalKeywords.cs
+++ b/Assets/HoloToolkit/Input/Tests/Scripts/SphereGlobalKeywords.cs
@@ -17,7 +17,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
                 cachedChildMaterials = new Material[childRenderers.Length];
                 for (int i = 0; i < childRenderers.Length; i++)
                 {
-                    cachedChildMaterials[i] = childRenderers[i].sharedMaterial;
+                    cachedChildMaterials[i] = childRenderers[i].material;
                 }
             }
         }
@@ -32,6 +32,14 @@ namespace HoloToolkit.Unity.InputModule.Tests
                         cachedChildMaterial.SetColor("_Color", Color.gray);
                     }
                     break;
+            }
+        }
+
+        private void OnDestroy()
+        {
+            for (int i = 0; i < cachedChildMaterials.Length; i++)
+            {
+                DestroyImmediate(cachedChildMaterials[i]);
             }
         }
     }

--- a/Assets/HoloToolkit/Input/Tests/Scripts/SphereKeywords.cs
+++ b/Assets/HoloToolkit/Input/Tests/Scripts/SphereKeywords.cs
@@ -1,25 +1,32 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using UnityEngine;
 
 namespace HoloToolkit.Unity.InputModule.Tests
 {
+    [RequireComponent(typeof(Renderer))]
     public class SphereKeywords : MonoBehaviour, ISpeechHandler
     {
+        private Material cachedMaterial;
+
+        private void Awake()
+        {
+            cachedMaterial = GetComponent<Renderer>().sharedMaterial;
+        }
+
         public void ChangeColor(string color)
         {
             switch (color.ToLower())
             {
                 case "red":
-                    GetComponent<Renderer>().material.color = Color.red;
+                    cachedMaterial.SetColor("_Color", Color.red);
                     break;
                 case "blue":
-                    GetComponent<Renderer>().material.color = Color.blue;
+                    cachedMaterial.SetColor("_Color", Color.blue);
                     break;
                 case "green":
-                    GetComponent<Renderer>().material.color = Color.green;
+                    cachedMaterial.SetColor("_Color", Color.green);
                     break;
             }
         }

--- a/Assets/HoloToolkit/Input/Tests/Scripts/SphereKeywords.cs
+++ b/Assets/HoloToolkit/Input/Tests/Scripts/SphereKeywords.cs
@@ -12,7 +12,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
 
         private void Awake()
         {
-            cachedMaterial = GetComponent<Renderer>().sharedMaterial;
+            cachedMaterial = GetComponent<Renderer>().material;
         }
 
         public void ChangeColor(string color)
@@ -34,6 +34,11 @@ namespace HoloToolkit.Unity.InputModule.Tests
         public void OnSpeechKeywordRecognized(SpeechKeywordRecognizedEventData eventData)
         {
             ChangeColor(eventData.RecognizedText);
+        }
+
+        private void OnDestroy()
+        {
+            DestroyImmediate(cachedMaterial);
         }
     }
 }

--- a/Assets/HoloToolkit/Input/Tests/Scripts/TestButton.cs
+++ b/Assets/HoloToolkit/Input/Tests/Scripts/TestButton.cs
@@ -105,7 +105,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
             // Set the initial alpha
             if (ToolTipRenderer != null)
             {
-                cachedToolTipMaterial = ToolTipRenderer.sharedMaterial;
+                cachedToolTipMaterial = ToolTipRenderer.material;
 
                 Color tipColor = cachedToolTipMaterial.GetColor("_Color");
                 tipColor.a = 0.0f;
@@ -230,6 +230,11 @@ namespace HoloToolkit.Unity.InputModule.Tests
             Focused = false;
 
             UpdateVisuals();
+        }
+
+        private void OnDestroy()
+        {
+            DestroyImmediate(cachedToolTipMaterial);
         }
     }
 }

--- a/Assets/HoloToolkit/Input/Tests/Scripts/TestButton.cs
+++ b/Assets/HoloToolkit/Input/Tests/Scripts/TestButton.cs
@@ -33,6 +33,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
         public bool EnableActivation = true;
 
         private AnimatorControllerParameter[] animatorHashes;
+        private Material cachedToolTipMaterial;
 
         private bool focused;
         public bool Focused
@@ -101,13 +102,14 @@ namespace HoloToolkit.Unity.InputModule.Tests
 
         protected virtual void OnEnable()
         {
-
             // Set the initial alpha
             if (ToolTipRenderer != null)
             {
-                Color tipColor = ToolTipRenderer.material.color;
+                cachedToolTipMaterial = ToolTipRenderer.sharedMaterial;
+
+                Color tipColor = cachedToolTipMaterial.GetColor("_Color");
                 tipColor.a = 0.0f;
-                ToolTipRenderer.material.color = tipColor;
+                cachedToolTipMaterial.SetColor("_Color", tipColor);
                 toolTipTimer = 0.0f;
             }
 
@@ -135,9 +137,9 @@ namespace HoloToolkit.Unity.InputModule.Tests
                 // Update the new opacity
                 if (ToolTipRenderer != null)
                 {
-                    Color tipColor = ToolTipRenderer.material.color;
+                    Color tipColor = cachedToolTipMaterial.GetColor("_Color");
                     tipColor.a = Mathf.Clamp(toolTipTimer, 0, ToolTipFadeTime) / ToolTipFadeTime;
-                    ToolTipRenderer.material.color = tipColor;
+                    cachedToolTipMaterial.SetColor("_Color", tipColor);
                 }
             }
         }

--- a/Assets/HoloToolkit/Sharing/Scripts/Utilities/Utils.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/Utilities/Utils.cs
@@ -112,12 +112,12 @@ namespace HoloToolkit.Sharing.Utilities
         }
 
         /// <summary>
-        /// Change material for every object in hierarchy which has a name equal to nameToTest.
-        ///  http://answers.unity3d.com/questions/548420/material-memory-leak.html
+        /// Change material for every object in hierarchy which has a name equal to nameToTest.  WARNING! 
+        /// <see cref="http://answers.unity3d.com/questions/548420/material-memory-leak.html">See Community Answer</see>
         /// This function automatically instantiates the materials and makes them unique to this renderer.
         /// It is your responsibility to destroy the materials when the game object is being destroyed.
         /// Resources.UnloadUnusedAssets also destroys the materials but it is usually only called when loading a new level.
-        /// https://docs.unity3d.com/ScriptReference/Renderer-material.html
+        /// <see cref="https://docs.unity3d.com/ScriptReference/Renderer-material.html">See Unity Documentation</see>
         /// </summary>
         /// <param name="t">root transform to start looking for renderers</param>
         /// <param name="mat">material to set everything to</param>

--- a/Assets/HoloToolkit/Sharing/Scripts/Utilities/Utils.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/Utilities/Utils.cs
@@ -112,22 +112,29 @@ namespace HoloToolkit.Sharing.Utilities
         }
 
         /// <summary>
-        /// Change material for every object in hierarchy which has a name equal to nameToTest
+        /// Change material for every object in hierarchy which has a name equal to nameToTest.
+        ///  http://answers.unity3d.com/questions/548420/material-memory-leak.html
+        /// This function automatically instantiates the materials and makes them unique to this renderer.
+        /// It is your responsibility to destroy the materials when the game object is being destroyed.
+        /// Resources.UnloadUnusedAssets also destroys the materials but it is usually only called when loading a new level.
+        /// https://docs.unity3d.com/ScriptReference/Renderer-material.html
         /// </summary>
         /// <param name="t">root transform to start looking for renderers</param>
         /// <param name="mat">material to set everything to</param>
-        /// <param name="ignoreName">ignore GameObjects with this name</param>
+        /// <param name="nameToTest">ignore GameObjects with this name</param>
         public static void SetMaterialRecursiveForName(Transform t, Material mat, string nameToTest)
         {
             if (t.gameObject && t.gameObject.GetComponent<Renderer>() && t.gameObject.name == nameToTest)
             {
-                t.gameObject.GetComponent<Renderer>().material = mat;
+                t.gameObject.GetComponent<Renderer>().sharedMaterial = mat;
             }
 
             for (int ii = 0; ii < t.childCount; ++ii)
             {
                 SetMaterialRecursiveForName(t.GetChild(ii), mat, nameToTest);
             }
+
+            Resources.UnloadUnusedAssets();
         }
 
         /// <summary>

--- a/Assets/HoloToolkit/Sharing/Scripts/Utilities/Utils.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/Utilities/Utils.cs
@@ -126,7 +126,7 @@ namespace HoloToolkit.Sharing.Utilities
         {
             if (t.gameObject && t.gameObject.GetComponent<Renderer>() && t.gameObject.name == nameToTest)
             {
-                t.gameObject.GetComponent<Renderer>().sharedMaterial = mat;
+                t.gameObject.GetComponent<Renderer>().material = mat;
             }
 
             for (int ii = 0; ii < t.childCount; ++ii)

--- a/Assets/HoloToolkit/Utilities/Scripts/DirectionIndicator.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/DirectionIndicator.cs
@@ -34,6 +34,9 @@ namespace HoloToolkit.Unity
         // Cache the MeshRenderer for the on-cursor indicator since it will be enabled and disabled frequently.
         private Renderer directionIndicatorRenderer;
 
+        // Cache the Material to prevent material leak.
+        private Material indicatorMaterial;
+
         // Check if the cursor direction indicator is visible.
         private bool isDirectionIndicatorVisible;
 
@@ -60,6 +63,7 @@ namespace HoloToolkit.Unity
 
         public void OnDestroy()
         {
+            DestroyImmediate(indicatorMaterial);
             Destroy(DirectionIndicatorObject);
         }
 
@@ -90,7 +94,7 @@ namespace HoloToolkit.Unity
                 Destroy(rigidBody);
             }
 
-            Material indicatorMaterial = directionIndicatorRenderer.sharedMaterial;
+            indicatorMaterial = directionIndicatorRenderer.material;
             indicatorMaterial.color = DirectionIndicatorColor;
             indicatorMaterial.SetColor("_TintColor", DirectionIndicatorColor);
 

--- a/Assets/HoloToolkit/Utilities/Scripts/DirectionIndicator.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/DirectionIndicator.cs
@@ -55,13 +55,12 @@ namespace HoloToolkit.Unity
             if (DirectionIndicatorObject == null)
             {
                 Debug.LogError("Direction Indicator failed to instantiate.");
-                return;
             }
         }
 
         public void OnDestroy()
         {
-            GameObject.Destroy(DirectionIndicatorObject);
+            Destroy(DirectionIndicatorObject);
         }
 
         private GameObject InstantiateDirectionIndicator(GameObject directionIndicator)
@@ -81,9 +80,9 @@ namespace HoloToolkit.Unity
             directionIndicatorRenderer.enabled = false;
 
             // Remove any colliders and rigidbodies so the indicators do not interfere with Unity's physics system.
-            foreach (Collider collider in indicator.GetComponents<Collider>())
+            foreach (Collider indicatorCollider in indicator.GetComponents<Collider>())
             {
-                Destroy(collider);
+                Destroy(indicatorCollider);
             }
 
             foreach (Rigidbody rigidBody in indicator.GetComponents<Rigidbody>())
@@ -91,7 +90,7 @@ namespace HoloToolkit.Unity
                 Destroy(rigidBody);
             }
 
-            Material indicatorMaterial = directionIndicatorRenderer.material;
+            Material indicatorMaterial = directionIndicatorRenderer.sharedMaterial;
             indicatorMaterial.color = DirectionIndicatorColor;
             indicatorMaterial.SetColor("_TintColor", DirectionIndicatorColor);
 
@@ -132,14 +131,11 @@ namespace HoloToolkit.Unity
             // This will return true if the target's mesh is within the Main Camera's view frustums.
             Vector3 targetViewportPosition = Camera.main.WorldToViewportPoint(gameObject.transform.position);
             return (targetViewportPosition.x > VisibilitySafeFactor && targetViewportPosition.x < 1 - VisibilitySafeFactor &&
-                targetViewportPosition.y > VisibilitySafeFactor && targetViewportPosition.y < 1 - VisibilitySafeFactor &&
-                targetViewportPosition.z > 0);
+                    targetViewportPosition.y > VisibilitySafeFactor && targetViewportPosition.y < 1 - VisibilitySafeFactor &&
+                    targetViewportPosition.z > 0);
         }
 
-        private void GetDirectionIndicatorPositionAndRotation(
-            Vector3 camToObjectDirection,
-            out Vector3 position,
-            out Quaternion rotation)
+        private void GetDirectionIndicatorPositionAndRotation(Vector3 camToObjectDirection, out Vector3 position, out Quaternion rotation)
         {
             // Find position:
             // Save the cursor transform position in a variable.
@@ -160,9 +156,7 @@ namespace HoloToolkit.Unity
             position = origin + cursorIndicatorDirection * MetersFromCursor;
 
             // Find the rotation from the facing direction to the target object.
-            rotation = Quaternion.LookRotation(
-                Camera.main.transform.forward,
-                cursorIndicatorDirection) * directionIndicatorDefaultRotation;
+            rotation = Quaternion.LookRotation(Camera.main.transform.forward, cursorIndicatorDirection) * directionIndicatorDefaultRotation;
         }
     }
 }


### PR DESCRIPTION
https://github.com/Microsoft/HoloToolkit-Unity/issues/236
https://github.com/Microsoft/HoloToolkit-Unity/pull/354

http://answers.unity3d.com/questions/548420/material-memory-leak.html

> void OnDestroy() { DestroyImmediate(renderer.material); }

https://docs.unity3d.com/ScriptReference/Renderer-material.html
>Renderer.material
>
> public Material material;
> Description
> 
> Returns the first instantiated Material assigned to the renderer.
> 
> Modifying material will change the material for this object only.
> 
> If the material is used by any other renderers, this will clone the shared material and start using it from now on.
> 
> Note:
> This function automatically instantiates the materials and makes them unique to this renderer. 
> **It is your responsibility to destroy the materials when the game object is being destroyed.** Resources.UnloadUnusedAssets also destroys the materials but it is usually only called when loading a new level.