### PR TITLE
It makes no sense to hide the cursor when there is no cursor listed

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Cursor/ObjectCursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/ObjectCursor.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Linq;
 using UnityEngine;
 
 namespace HoloToolkit.Unity.InputModule
@@ -33,7 +34,7 @@ namespace HoloToolkit.Unity.InputModule
         /// </summary>
         protected override void OnEnable()
         {
-            if(ParentTransform == null)
+            if (ParentTransform == null)
             {
                 ParentTransform = transform;
             }
@@ -48,7 +49,6 @@ namespace HoloToolkit.Unity.InputModule
         public override void OnCursorStateChange(CursorStateEnum state)
         {
             base.OnCursorStateChange(state);
-
             if (state != CursorStateEnum.Contextual)
             {
                 ObjectCursorDatum newActive = CursorStateData.FirstOrDefault(p => p.CursorState == state);
@@ -64,6 +64,7 @@ namespace HoloToolkit.Unity.InputModule
                 }
 
                 newActive.CursorObject.SetActive(true);
+            }
         }
     }
 }

--- a/Assets/HoloToolkit/Input/Scripts/Cursor/ObjectCursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/ObjectCursor.cs
@@ -51,21 +51,19 @@ namespace HoloToolkit.Unity.InputModule
 
             if (state != CursorStateEnum.Contextual)
             {
-                // Hide all children first
-                for(int i = 0; i < ParentTransform.childCount; i++)
+                var newActive = CursorStateData.FirstOrDefault(p => p.CursorState == state);
+                if (newActive.Name == null)
                 {
-                    ParentTransform.GetChild(i).gameObject.SetActive(false);
+                    return;
                 }
 
-                // Set active any that match the current state
-                for (int i = 0; i < CursorStateData.Length; i++)
+                var oldActive = CursorStateData.FirstOrDefault(p => p.CursorObject.activeSelf);
+                if (oldActive.Name != null)
                 {
-                    if (CursorStateData[i].CursorState == state)
-                    {
-                        CursorStateData[i].CursorObject.SetActive(true);
-                    }
+                    oldActive.CursorObject.SetActive(false);
                 }
-            }
+
+                newActive.CursorObject.SetActive(true);
         }
     }
 }

--- a/Assets/HoloToolkit/Input/Scripts/Cursor/ObjectCursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/ObjectCursor.cs
@@ -37,6 +37,12 @@ namespace HoloToolkit.Unity.InputModule
             {
                 ParentTransform = transform;
             }
+
+            for (int i = 0; i < ParentTransform.childCount; i++)
+            {
+                ParentTransform.GetChild(i).gameObject.SetActive(false);
+            }
+
             base.OnEnable();
         }
 

--- a/Assets/HoloToolkit/Input/Scripts/Cursor/ObjectCursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/ObjectCursor.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
-using System.Linq;
 using UnityEngine;
 
 namespace HoloToolkit.Unity.InputModule
@@ -34,7 +33,7 @@ namespace HoloToolkit.Unity.InputModule
         /// </summary>
         protected override void OnEnable()
         {
-            if (ParentTransform == null)
+            if(ParentTransform == null)
             {
                 ParentTransform = transform;
             }
@@ -51,16 +50,30 @@ namespace HoloToolkit.Unity.InputModule
             base.OnCursorStateChange(state);
             if (state != CursorStateEnum.Contextual)
             {
-                ObjectCursorDatum newActive = CursorStateData.FirstOrDefault(p => p.CursorState == state);
+                var newActive = new ObjectCursorDatum();
+                for(int i = 0; i < CursorStateData.Length; i++)
+                {
+                    ObjectCursorDatum c = CursorStateData[i];
+                    if (c.CursorState == state)
+                    {
+                        newActive = c;
+                        break;
+                    }
+                }
+
                 if (newActive.Name == null)
                 {
                     return;
                 }
 
-                ObjectCursorDatum oldActive = CursorStateData.FirstOrDefault(p => p.CursorObject.activeSelf);
-                if (oldActive.Name != null)
+                for(int i = 0; i < CursorStateData.Length; i++)
                 {
-                    oldActive.CursorObject.SetActive(false);
+                    ObjectCursorDatum c = CursorStateData[i];
+                    if (c.CursorObject.activeSelf)
+                    {
+                        c.CursorObject.SetActive(false);
+                        break;
+                    }
                 }
 
                 newActive.CursorObject.SetActive(true);

--- a/Assets/HoloToolkit/Input/Scripts/Cursor/ObjectCursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/ObjectCursor.cs
@@ -56,32 +56,39 @@ namespace HoloToolkit.Unity.InputModule
             base.OnCursorStateChange(state);
             if (state != CursorStateEnum.Contextual)
             {
+
+                // First, try to find a cursor for the current state
                 var newActive = new ObjectCursorDatum();
-                for(int i = 0; i < CursorStateData.Length; i++)
+                for(int cursorIndex = 0; cursorIndex < CursorStateData.Length; cursorIndex++)
                 {
-                    ObjectCursorDatum c = CursorStateData[i];
-                    if (c.CursorState == state)
+                    ObjectCursorDatum cursor = CursorStateData[cursorIndex];
+                    if (cursor.CursorState == state)
                     {
-                        newActive = c;
+                        newActive = cursor;
                         break;
                     }
                 }
 
+                // If no cursor for current state is found, let the last active cursor be
+                // (any cursor is better than an invisible cursor)
                 if (newActive.Name == null)
                 {
                     return;
                 }
 
-                for(int i = 0; i < CursorStateData.Length; i++)
+                // If we come here, there is a cursor for the new state, 
+                // so de-activate a possible earlier active cursor
+                for(int cursorIndex = 0; cursorIndex < CursorStateData.Length; cursorIndex++)
                 {
-                    ObjectCursorDatum c = CursorStateData[i];
-                    if (c.CursorObject.activeSelf)
+                    ObjectCursorDatum cursor = CursorStateData[cursorIndex];
+                    if (cursor.CursorObject.activeSelf)
                     {
-                        c.CursorObject.SetActive(false);
+                        cursor.CursorObject.SetActive(false);
                         break;
                     }
                 }
 
+                // ... and set the cursor for the new state active.
                 newActive.CursorObject.SetActive(true);
             }
         }

--- a/Assets/HoloToolkit/Input/Scripts/Cursor/ObjectCursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/ObjectCursor.cs
@@ -51,13 +51,13 @@ namespace HoloToolkit.Unity.InputModule
 
             if (state != CursorStateEnum.Contextual)
             {
-                var newActive = CursorStateData.FirstOrDefault(p => p.CursorState == state);
+                ObjectCursorDatum newActive = CursorStateData.FirstOrDefault(p => p.CursorState == state);
                 if (newActive.Name == null)
                 {
                     return;
                 }
 
-                var oldActive = CursorStateData.FirstOrDefault(p => p.CursorObject.activeSelf);
+                ObjectCursorDatum oldActive = CursorStateData.FirstOrDefault(p => p.CursorObject.activeSelf);
                 if (oldActive.Name != null)
                 {
                     oldActive.CursorObject.SetActive(false);


### PR DESCRIPTION
It makes no sense to hide the cursor when there is no cursor listed for a given state. It's better just retain the last one. Otherwise you are obliged to add a cursor for EVERY possible state.