### PR TITLE
Added unit tests for VectorExtensions

### DIFF
--- a/Assets/HoloToolkit-UnitTests.meta
+++ b/Assets/HoloToolkit-UnitTests.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: a6bafb6bff161e84bb377911fb4a0258
+folderAsset: yes
+timeCreated: 1482405388
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit-UnitTests/Editor.meta
+++ b/Assets/HoloToolkit-UnitTests/Editor.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 33b30aa4e5ee310479496658ccee5869
+folderAsset: yes
+timeCreated: 1482405394
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit-UnitTests/Editor/Utilities.meta
+++ b/Assets/HoloToolkit-UnitTests/Editor/Utilities.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: d2d8d2678be409c43b970d5273b20b59
+folderAsset: yes
+timeCreated: 1482405414
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit-UnitTests/Editor/Utilities/Extensions.meta
+++ b/Assets/HoloToolkit-UnitTests/Editor/Utilities/Extensions.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: a322a1b5b13ea0c47914f262e842cbe2
+folderAsset: yes
+timeCreated: 1482405425
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit-UnitTests/Editor/Utilities/Extensions/VectorExtensionsTests.cs
+++ b/Assets/HoloToolkit-UnitTests/Editor/Utilities/Extensions/VectorExtensionsTests.cs
@@ -78,10 +78,24 @@ namespace HoloToolkit.Unity.Tests
         }
 
         [Test]
+        public void Vector2Collection_Average_Empty()
+        {
+            var vectors = new Vector2[] { };
+            Assert.That(VectorExtensions.Average(vectors), Is.EqualTo(Vector2.zero));
+        }
+
+        [Test]
         public void Vector3Collection_Average_Empty()
         {
             var vectors = new Vector3[] { };
             Assert.That(VectorExtensions.Average(vectors), Is.EqualTo(Vector3.zero));
+        }
+
+        [Test]
+        public void Vector2Collection_Average()
+        {
+            var vectors = new Vector2[] { new Vector2(1f, 2f), new Vector2(2f, 3f) };
+            Assert.That(VectorExtensions.Average(vectors), Is.EqualTo(new Vector2(1.5f, 2.5f)));
         }
 
         [Test]
@@ -92,10 +106,24 @@ namespace HoloToolkit.Unity.Tests
         }
 
         [Test]
+        public void Vector2Collection_Median_Empty()
+        {
+            var vectors = new Vector2[] { };
+            Assert.That(VectorExtensions.Median(vectors), Is.EqualTo(Vector2.zero));
+        }
+
+        [Test]
         public void Vector3Collection_Median_Empty()
         {
             var vectors = new Vector3[] { };
             Assert.That(VectorExtensions.Median(vectors), Is.EqualTo(Vector3.zero));
+        }
+
+        [Test]
+        public void Vector2Collection_Median()
+        {
+            var vectors = new Vector2[] { new Vector3(10f, 10f), new Vector2(1f, 1f), new Vector2(5f, 5f) };
+            Assert.That(VectorExtensions.Median(vectors), Is.EqualTo(new Vector2(5f, 5f)));
         }
 
         [Test]

--- a/Assets/HoloToolkit-UnitTests/Editor/Utilities/Extensions/VectorExtensionsTests.cs
+++ b/Assets/HoloToolkit-UnitTests/Editor/Utilities/Extensions/VectorExtensionsTests.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace HoloToolkit.Unity.Tests
+{
+    public class VectorExtensionsTests
+    {
+        [Test]
+        public void Vector2_Mul()
+        {
+            Vector2 value = new Vector2(2f, 3f);
+            Vector2 scale = new Vector2(2f, 3f);
+            Vector2 expected = new Vector2(4f, 9f);
+            Assert.That(value.Mul(scale), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void Vector2_Div()
+        {
+            Vector2 value = new Vector2(2f, 3f);
+            Vector2 scale = new Vector2(2f, 3f);
+            Vector2 expected = new Vector2(1f, 1f);
+            Assert.That(value.Div(scale), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void Vector3_Mul()
+        {
+            Vector3 value = new Vector3(2f, 3f, 4f);
+            Vector3 scale = new Vector3(2f, 3f, 4f);
+            Vector3 expected = new Vector3(4f, 9f, 16f);
+            Assert.That(value.Mul(scale), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void Vector3_Div()
+        {
+            Vector3 value = new Vector3(2f, 3f, 4f);
+            Vector3 scale = new Vector3(2f, 3f, 4f);
+            Vector3 expected = new Vector3(1f, 1f, 1f);
+            Assert.That(value.Div(scale), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void Vector3_RotateAround_Quaternion()
+        {
+            Vector3 point = new Vector3(0f, 0f, 0f);
+            Vector3 pivot = new Vector3(1f, 1f, 1f);
+            Quaternion rotation = Quaternion.AngleAxis(180f, new Vector3(0f, 0f, 1f));
+            Vector3 expected = new Vector3(2f, 2f, 0f);
+            Assert.That(point.RotateAround(pivot, rotation), Is.EqualTo(expected).Within(1f).Ulps);
+        }
+
+        [Test]
+        public void Vector3_RotateAround_Euler()
+        {
+            Vector3 point = new Vector3(0f, 0f, 0f);
+            Vector3 pivot = new Vector3(1f, 1f, 1f);
+            Vector3 rotation = new Vector3(0f, 0f, 180f);
+            Vector3 expected = new Vector3(2f, 2f, 0f);
+            Assert.That(point.RotateAround(pivot, rotation), Is.EqualTo(expected).Within(1f).Ulps);
+        }
+
+        [Test]
+        public void Vector3_TransformPoint()
+        {
+            throw new NotImplementedException();
+        }
+
+        [Test]
+        public void Vector3_InverseTransformPoint()
+        {
+            throw new NotImplementedException();
+        }
+
+        [Test]
+        public void Vector3Collection_Average_Empty()
+        {
+            var vectors = new Vector3[] { };
+            Assert.That(VectorExtensions.Average(vectors), Is.EqualTo(Vector3.zero));
+        }
+
+        [Test]
+        public void Vector3Collection_Average()
+        {
+            var vectors = new Vector3[] { new Vector3(1f, 2f, 3f), new Vector3(2f, 3f, 4f) };
+            Assert.That(VectorExtensions.Average(vectors), Is.EqualTo(new Vector3(1.5f, 2.5f, 3.5f)));
+        }
+
+        [Test]
+        public void Vector3Collection_Median_Empty()
+        {
+            var vectors = new Vector3[] { };
+            Assert.That(VectorExtensions.Median(vectors), Is.EqualTo(Vector3.zero));
+        }
+
+        [Test]
+        public void Vector3Collection_Median()
+        {
+            var vectors = new Vector3[] { new Vector3(10f, 10f, 10f), new Vector3(1f, 1f, 1f), new Vector3(5f, 5f, 5f) };
+            Assert.That(VectorExtensions.Median(vectors), Is.EqualTo(new Vector3(5f, 5f, 5f)));
+        }
+
+    }
+}

--- a/Assets/HoloToolkit-UnitTests/Editor/Utilities/Extensions/VectorExtensionsTests.cs.meta
+++ b/Assets/HoloToolkit-UnitTests/Editor/Utilities/Extensions/VectorExtensionsTests.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: e3acf3353ff8c1b4e88f535350bfdd41
+timeCreated: 1482405443
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HoloToolkit-UnitTests/README.md
+++ b/Assets/HoloToolkit-UnitTests/README.md
@@ -1,0 +1,16 @@
+# HoloToolkit-UnitTests
+This folder will host unit tests that test individual HoloToolkit-Unity components.
+
+#### Creating a unit test:
+
+1. Unit tests can be located anywhere under an Editor folder but consider placing it under the HoloToolkit-UnitTests\Editor folder so that HoloToolkit-Unity can be easily deployed without the tests if required.
+2. Use the **NUnit 2.6.4** features to create the tests.
+3. Cover us much as possible the new code so that other people can test your code even without knowing its internals.
+4. Execute all the tests before submitting a pull request.
+
+#### Running the unit tests:
+
+1. Unit tests execution is integrated into the Unity editor (since 5.3). 
+2. Open the **Editor Tests** window by clicking on the menu item **Window** | **Editor Tests Runner**.
+3. Click on the buttons **Run All**, **Run Selected** or **Run Failed** to run the tests. 
+

--- a/Assets/HoloToolkit-UnitTests/README.md.meta
+++ b/Assets/HoloToolkit-UnitTests/README.md.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e3f887734ab08b845af5a06c46a55268
+timeCreated: 1485702368
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
It's hard for the reviewers to test all functionalities so I think it's a good idea to start enforcing a unit tests requirement.
Here is an example for the VectorExtensions. While working on it, I noticed that the latest functionalities added are actually not extensions. One good reason for them to exist...
I placed the unit tests in a HoloToolkit-UnitTests folder under Assets to keep the HoloToolkit deployment simple.
Unit tests execution is integrated into the Unity editor (since 5.3). It doesn't require the Unity Test Tools from the asset store.
To run all the tests: 
1. Click on the menu item Window | Editor Tests Runner. 
2. Click on the button Run All.
 
 

