### PR TITLE
Support lerping with unscaled time to enable pause menus

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
@@ -305,7 +305,7 @@ namespace HoloToolkit.Unity.InputModule
                 }
             }
 
-            var deltaTime = UseUnscaledTime
+            float deltaTime = UseUnscaledTime
                 ? Time.unscaledDeltaTime
                 : Time.deltaTime;
 

--- a/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
@@ -23,11 +23,11 @@ namespace HoloToolkit.Unity.InputModule
             /// <summary>
             /// Not IsHandVisible
             /// </summary>
-            Observe, 
+            Observe,
             /// <summary>
             /// Not IsHandVisible AND not IsInputSourceDown AND TargetedObject exists
             /// </summary>
-            ObserveHover, 
+            ObserveHover,
             /// <summary>
             /// IsHandVisible AND not IsInputSourceDown AND TargetedObject is NULL
             /// </summary>
@@ -73,10 +73,13 @@ namespace HoloToolkit.Unity.InputModule
         [Tooltip("The distance from the hit surface to place the cursor")]
         public float SurfaceCursorDistance = 0.02f;
 
+        [Header("Motion")]
+        [Tooltip("When lerping, use unscaled time. This is useful for games that have a pause mechanism or otherwise adjust the game timescale.")]
+        public bool UseUnscaledTime = true;
+
         /// <summary>
         /// Blend value for surface normal to user facing lerp
         /// </summary>
-        [Header("Motion")]
         public float PositionLerpTime = 0.01f;
 
         /// <summary>
@@ -105,7 +108,7 @@ namespace HoloToolkit.Unity.InputModule
         {
             get { return transform.position; }
         }
-        
+
         public Quaternion Rotation
         {
             get { return transform.rotation; }
@@ -153,7 +156,7 @@ namespace HoloToolkit.Unity.InputModule
             }
         }
 
-#region MonoBehaviour Functions
+        #region MonoBehaviour Functions
 
         private void Awake()
         {
@@ -177,7 +180,7 @@ namespace HoloToolkit.Unity.InputModule
         /// <summary>
         /// Override for enable functions
         /// </summary>
-        protected virtual void OnEnable(){}
+        protected virtual void OnEnable() { }
 
         /// <summary>
         /// Override for disable functions
@@ -194,7 +197,7 @@ namespace HoloToolkit.Unity.InputModule
             UnregisterManagers();
         }
 
-#endregion
+        #endregion
 
         /// <summary>
         /// Register to events from the managers the cursor needs.
@@ -302,17 +305,21 @@ namespace HoloToolkit.Unity.InputModule
                 }
             }
 
+            var deltaTime = UseUnscaledTime
+                ? Time.unscaledDeltaTime
+                : Time.deltaTime;
+
             // Use the lerp times to blend the position to the target position
-            transform.position = Vector3.Lerp(transform.position, targetPosition, Time.deltaTime / PositionLerpTime);
-            transform.localScale = Vector3.Lerp(transform.localScale, targetScale, Time.deltaTime / ScaleLerpTime);
-            transform.rotation = Quaternion.Lerp(transform.rotation, targetRotation, Time.deltaTime / RotationLerpTime);
+            transform.position = Vector3.Lerp(transform.position, targetPosition, deltaTime / PositionLerpTime);
+            transform.localScale = Vector3.Lerp(transform.localScale, targetScale, deltaTime / ScaleLerpTime);
+            transform.rotation = Quaternion.Lerp(transform.rotation, targetRotation, deltaTime / RotationLerpTime);
         }
 
         /// <summary>
         /// Updates the visual representation of the cursor.
         /// </summary>
         public void SetVisiblity(bool visible)
-        { 
+        {
             if (PrimaryCursorVisual != null)
             {
                 PrimaryCursorVisual.gameObject.SetActive(visible);
@@ -414,7 +421,7 @@ namespace HoloToolkit.Unity.InputModule
                 {
                     return CursorStateEnum.Select;
                 }
-                else if(cursorState == CursorStateEnum.Select)
+                else if (cursorState == CursorStateEnum.Select)
                 {
                     return CursorStateEnum.Release;
                 }

--- a/Assets/HoloToolkit/Input/Scripts/InputSources/EditorHandsInput.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputSources/EditorHandsInput.cs
@@ -39,7 +39,7 @@ namespace HoloToolkit.Unity.InputModule
             public bool IsFingerDownPending;
             public bool FingerStateChanged;
             public float FingerStateUpdateTimer;
-			public float FingerDownStartTime;
+            public float FingerDownStartTime;
             public readonly InputSourceEventArgs InputSourceArgs;
         }
 
@@ -56,15 +56,15 @@ namespace HoloToolkit.Unity.InputModule
         /// </summary>
         private const float FingerPressDelay = 0.07f;
 
-		/// <summary>
-		/// The maximum interval between button down and button up that will result in a clicked event.
-		/// </summary>
-		private const float MaxClickDuration = 0.5f;
+        /// <summary>
+        /// The maximum interval between button down and button up that will result in a clicked event.
+        /// </summary>
+        private const float MaxClickDuration = 0.5f;
 
-		/// <summary>
-		/// Number of fake hands supported in the editor.
-		/// </summary>
-		private const int EditorHandsCount = 2;
+        /// <summary>
+        /// Number of fake hands supported in the editor.
+        /// </summary>
+        private const int EditorHandsCount = 2;
 
         /// <summary>
         /// Array containing the hands data for the two fake hands
@@ -205,19 +205,33 @@ namespace HoloToolkit.Unity.InputModule
         /// </summary>
         private void UpdateHandData()
         {
+            float time;
+            float deltaTime;
+
+            if (manualHandControl.UseUnscaledTime)
+            {
+                time = Time.unscaledTime;
+                deltaTime = Time.unscaledDeltaTime;
+            }
+            else
+            {
+                time = Time.time;
+                deltaTime = Time.deltaTime;
+            }
+
             if (manualHandControl.LeftHandInView)
             {
                 GetOrAddHandData(0);
                 currentHands.Add(0);
 
-                UpdateHandState(manualHandControl.LeftHandSourceState, editorHandsData[0]);
+                UpdateHandState(manualHandControl.LeftHandSourceState, editorHandsData[0], deltaTime, time);
             }
 
             if (manualHandControl.RightHandInView)
             {
                 GetOrAddHandData(1);
                 currentHands.Add(1);
-                UpdateHandState(manualHandControl.RightHandSourceState, editorHandsData[1]);
+                UpdateHandState(manualHandControl.RightHandSourceState, editorHandsData[1], deltaTime, time);
             }
         }
 
@@ -245,7 +259,7 @@ namespace HoloToolkit.Unity.InputModule
         /// </summary>
         /// <param name="handSource">Hand source to use to update the position.</param>
         /// <param name="editorHandData">EditorHandData structure to update.</param>
-        private void UpdateHandState(DebugInteractionSourceState handSource, EditorHandData editorHandData)
+        private void UpdateHandState(DebugInteractionSourceState handSource, EditorHandData editorHandData, float deltaTime, float time)
         {
             // Update hand position
             Vector3 handPosition;
@@ -266,26 +280,26 @@ namespace HoloToolkit.Unity.InputModule
             editorHandData.FingerStateChanged = false;
             if (editorHandData.FingerStateUpdateTimer > 0)
             {
-                editorHandData.FingerStateUpdateTimer -= Time.deltaTime;
+                editorHandData.FingerStateUpdateTimer -= deltaTime;
                 if (editorHandData.FingerStateUpdateTimer <= 0)
                 {
                     editorHandData.IsFingerDown = editorHandData.IsFingerDownPending;
                     editorHandData.FingerStateChanged = true;
-					if (editorHandData.IsFingerDown)
-					{
-						editorHandData.FingerDownStartTime = Time.time;
-					}
+                    if (editorHandData.IsFingerDown)
+                    {
+                        editorHandData.FingerDownStartTime = time;
+                    }
                 }
             }
 
-            SendHandStateEvents(editorHandData);
+            SendHandStateEvents(editorHandData, time);
         }
 
         /// <summary>
         /// Sends the events for hand state changes.
         /// </summary>
         /// <param name="editorHandData">Hand data for which events should be sent.</param>
-        private void SendHandStateEvents(EditorHandData editorHandData)
+        private void SendHandStateEvents(EditorHandData editorHandData, float time)
         {
             // Hand moved event
             if (editorHandData.HandDelta.sqrMagnitude > 0)
@@ -305,12 +319,12 @@ namespace HoloToolkit.Unity.InputModule
                     RaiseSourceUpEvent(editorHandData.InputSourceArgs);
 
                     // Also send click event when using this hands replacement input
-					if (Time.time - editorHandData.FingerDownStartTime < MaxClickDuration)
-					{
+                    if (time - editorHandData.FingerDownStartTime < MaxClickDuration)
+                    {
                         // We currently only support single taps in editor
                         SourceClickEventArgs args = new SourceClickEventArgs(this, editorHandData.HandId, 1);
-						RaiseSourceClickedEvent(args);
-					}
+                        RaiseSourceClickedEvent(args);
+                    }
                 }
             }
         }

--- a/Assets/HoloToolkit/Input/Scripts/InputSources/RawInteractionSourcesInput.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputSources/RawInteractionSourcesInput.cs
@@ -183,7 +183,7 @@ namespace HoloToolkit.Unity.InputModule
             sourceData.SourceStateChanged = false;
             if (sourceData.SourceStateUpdateTimer >= 0)
             {
-                var deltaTime = UseUnscaledTime
+                float deltaTime = UseUnscaledTime
                     ? Time.unscaledDeltaTime
                     : Time.deltaTime;
 

--- a/Assets/HoloToolkit/Input/Scripts/InputSources/RawInteractionSourcesInput.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputSources/RawInteractionSourcesInput.cs
@@ -52,6 +52,9 @@ namespace HoloToolkit.Unity.InputModule
         /// </summary>
         private const float SourcePressDelay = 0.07f;
 
+        [Tooltip("Use unscaled time. This is useful for games that have a pause mechanism or otherwise adjust the game timescale.")]
+        public bool UseUnscaledTime = true;
+
         /// <summary>
         /// Dictionary linking each source ID to its data.
         /// </summary>
@@ -106,7 +109,7 @@ namespace HoloToolkit.Unity.InputModule
             orientation = Quaternion.identity;
             return false;
         }
-        
+
         private void Update()
         {
             newSources.Clear();
@@ -180,7 +183,11 @@ namespace HoloToolkit.Unity.InputModule
             sourceData.SourceStateChanged = false;
             if (sourceData.SourceStateUpdateTimer >= 0)
             {
-                sourceData.SourceStateUpdateTimer -= Time.deltaTime;
+                var deltaTime = UseUnscaledTime
+                    ? Time.unscaledDeltaTime
+                    : Time.deltaTime;
+
+                sourceData.SourceStateUpdateTimer -= deltaTime;
                 if (sourceData.SourceStateUpdateTimer < 0)
                 {
                     sourceData.IsSourceDown = sourceData.IsSourceDownPending;

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/AxisController.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/AxisController.cs
@@ -55,6 +55,9 @@ namespace HoloToolkit.Unity.InputModule
 
         public float SensitivityScale = 3.0f;
 
+        [Tooltip("Use unscaled time. This is useful for games that have a pause mechanism or otherwise adjust the game timescale.")]
+        public bool UseUnscaledTime = true;
+
         public AxisType axisType = AxisType.Mouse;
         public ButtonController.ButtonType buttonType = ButtonController.ButtonType.None;
 
@@ -82,19 +85,19 @@ namespace HoloToolkit.Unity.InputModule
 
         public bool AxisTypeIsKeyboard
         {
-            get{ return AxisType.KeyboardArrows <= axisType && axisType <= AxisType.KeyBoardHomeEndPgUpPgDown; }
+            get { return AxisType.KeyboardArrows <= axisType && axisType <= AxisType.KeyBoardHomeEndPgUpPgDown; }
         }
         public bool AxisTypeIsInputManagerAxis
         {
-            get{ return  axisType == AxisType.InputManagerAxis; }
+            get { return axisType == AxisType.InputManagerAxis; }
         }
         public bool AxisTypeIsMouse
         {
-            get{ return axisType == AxisType.Mouse; }
+            get { return axisType == AxisType.Mouse; }
         }
         public bool AxisTypeIsMouseScroll
         {
-            get{ return axisType == AxisType.MouseScroll; }
+            get { return axisType == AxisType.MouseScroll; }
         }
 
         public void EnableAndCheck(bool value)
@@ -136,9 +139,9 @@ namespace HoloToolkit.Unity.InputModule
             UnityEngine.Cursor.lockState = CursorLockMode.None;
             UnityEngine.Cursor.visible = true;
 #endif
-    }
+        }
 
-    private static float InputCurve(float x)
+        private static float InputCurve(float x)
         {
             // smoothing input curve, converts from [-1,1] to [-2,2]
             return (Mathf.Sign(x) * (1.0f - Mathf.Cos(.5f * Mathf.PI * Mathf.Clamp(x, -1.0f, 1.0f))));
@@ -379,52 +382,56 @@ namespace HoloToolkit.Unity.InputModule
 
         private Vector3 KeyboardLookTick()
         {
+            var deltaTime = UseUnscaledTime
+                ? Time.unscaledDeltaTime
+                : Time.deltaTime;
+
             Vector3 rot = Vector3.zero;
             if (axisType == AxisType.KeyboardArrows)
             {
-                rot.x += InputCurve(Time.deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.LeftArrow, KeyCode.RightArrow));
-                rot.y += InputCurve(Time.deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.DownArrow, KeyCode.UpArrow));
+                rot.x += InputCurve(deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.LeftArrow, KeyCode.RightArrow));
+                rot.y += InputCurve(deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.DownArrow, KeyCode.UpArrow));
             }
             else if (axisType == AxisType.KeyboardWASD)
             {
-                rot.x += InputCurve(Time.deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.A, KeyCode.D));
-                rot.y += InputCurve(Time.deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.S, KeyCode.W));
+                rot.x += InputCurve(deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.A, KeyCode.D));
+                rot.y += InputCurve(deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.S, KeyCode.W));
             }
             else if (axisType == AxisType.KeyboardQE)
             {
-                rot.x += InputCurve(Time.deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.Q, KeyCode.E));
+                rot.x += InputCurve(deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.Q, KeyCode.E));
             }
             else if (axisType == AxisType.KeyboardIJKL)
             {
-                rot.x += InputCurve(Time.deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.J, KeyCode.L));
-                rot.y += InputCurve(Time.deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.K, KeyCode.I));
+                rot.x += InputCurve(deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.J, KeyCode.L));
+                rot.y += InputCurve(deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.K, KeyCode.I));
             }
             else if (axisType == AxisType.KeyboardUO)
             {
-                rot.x += InputCurve(Time.deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.U, KeyCode.O));
+                rot.x += InputCurve(deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.U, KeyCode.O));
             }
             else if (axisType == AxisType.Keyboard8426)
             {
-                rot.x += InputCurve(Time.deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.Keypad4, KeyCode.Keypad6));
-                rot.y += InputCurve(Time.deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.Keypad2, KeyCode.Keypad8));
+                rot.x += InputCurve(deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.Keypad4, KeyCode.Keypad6));
+                rot.y += InputCurve(deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.Keypad2, KeyCode.Keypad8));
             }
             else if (axisType == AxisType.Keyboard7193)
             {
-                rot.x += InputCurve(Time.deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.Keypad1, KeyCode.Keypad7));
-                rot.y += InputCurve(Time.deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.Keypad3, KeyCode.Keypad9));
+                rot.x += InputCurve(deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.Keypad1, KeyCode.Keypad7));
+                rot.y += InputCurve(deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.Keypad3, KeyCode.Keypad9));
             }
             else if (axisType == AxisType.KeyboardPeriodComma)
             {
-                rot.x += InputCurve(Time.deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.Comma, KeyCode.Period));
+                rot.x += InputCurve(deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.Comma, KeyCode.Period));
             }
             else if (axisType == AxisType.KeyboardBrackets)
             {
-                rot.x += InputCurve(Time.deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.LeftBracket, KeyCode.RightBracket));
+                rot.x += InputCurve(deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.LeftBracket, KeyCode.RightBracket));
             }
             else if (axisType == AxisType.KeyBoardHomeEndPgUpPgDown)
             {
-                rot.x += InputCurve(Time.deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.End, KeyCode.Home));
-                rot.y += InputCurve(Time.deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.PageDown, KeyCode.PageUp));
+                rot.x += InputCurve(deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.End, KeyCode.Home));
+                rot.y += InputCurve(deltaTime * KeyboardSensitivity * GetKeyDir(KeyCode.PageDown, KeyCode.PageUp));
             }
             return rot;
         }

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/AxisController.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/AxisController.cs
@@ -382,7 +382,7 @@ namespace HoloToolkit.Unity.InputModule
 
         private Vector3 KeyboardLookTick()
         {
-            var deltaTime = UseUnscaledTime
+            float deltaTime = UseUnscaledTime
                 ? Time.unscaledDeltaTime
                 : Time.deltaTime;
 

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/ManualHandControl.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/ManualHandControl.cs
@@ -169,7 +169,7 @@ namespace HoloToolkit.Unity.InputModule
         {
             UpdateHandVisualization();
 
-            var deltaTime = UseUnscaledTime
+            float deltaTime = UseUnscaledTime
                 ? Time.unscaledDeltaTime
                 : Time.deltaTime;
 

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/ManualHandControl.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/ManualHandControl.cs
@@ -89,6 +89,9 @@ namespace HoloToolkit.Unity.InputModule
         public float HandTimeBeforeReturn = 0.5f;
         public float MinimumTrackedMovement = 0.001f;
 
+        [Tooltip("Use unscaled time. This is useful for games that have a pause mechanism or otherwise adjust the game timescale.")]
+        public bool UseUnscaledTime = true;
+
         public AxisController LeftHandPrimaryAxisControl;
         public AxisController LeftHandSecondaryAxisControl;
         public ButtonController LeftFingerUpButtonControl;
@@ -166,10 +169,14 @@ namespace HoloToolkit.Unity.InputModule
         {
             UpdateHandVisualization();
 
-            float smoothingFactor = Time.deltaTime * 30.0f * HandReturnFactor;
+            var deltaTime = UseUnscaledTime
+                ? Time.unscaledDeltaTime
+                : Time.deltaTime;
+
+            float smoothingFactor = deltaTime * 30.0f * HandReturnFactor;
             if (timeBeforeReturn > 0.0f)
             {
-                timeBeforeReturn = Mathf.Clamp(timeBeforeReturn - Time.deltaTime, 0.0f, HandTimeBeforeReturn);
+                timeBeforeReturn = Mathf.Clamp(timeBeforeReturn - deltaTime, 0.0f, HandTimeBeforeReturn);
             }
 
             LeftHandSourceState.Pressed = LeftFingerDownButtonControl.Pressed();

--- a/Assets/HoloToolkit/Utilities/Scripts/Interpolator.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Interpolator.cs
@@ -10,6 +10,9 @@ namespace HoloToolkit.Unity
     /// </summary>
     public class Interpolator : MonoBehaviour
     {
+        [Tooltip("When interpolating, use unscaled time. This is useful for games that have a pause mechanism or otherwise adjust the game timescale.")]
+        public bool UseUnscaledTime = true;
+
         // A very small number that is used in determining if the Interpolator
         // needs to run at all.
         private const float smallNumber = 0.0000001f;
@@ -261,6 +264,10 @@ namespace HoloToolkit.Unity
 
         public void Update()
         {
+            var deltaTime = UseUnscaledTime
+                ? Time.unscaledDeltaTime
+                : Time.deltaTime;
+
             bool interpOccuredThisFrame = false;
 
             if (AnimatingPosition)
@@ -271,7 +278,7 @@ namespace HoloToolkit.Unity
                     lerpTargetPosition = Vector3.Lerp(transform.position, lerpTargetPosition, SmoothPositionLerpRatio);
                 }
 
-                Vector3 newPosition = NonLinearInterpolateTo(transform.position, lerpTargetPosition, Time.deltaTime, PositionPerSecond);
+                Vector3 newPosition = NonLinearInterpolateTo(transform.position, lerpTargetPosition, deltaTime, PositionPerSecond);
                 if ((targetPosition - newPosition).sqrMagnitude <= smallNumber)
                 {
                     // Snap to final position
@@ -301,7 +308,7 @@ namespace HoloToolkit.Unity
 
                 float angleDiff = Quaternion.Angle(transform.rotation, lerpTargetRotation);
                 float speedScale = 1.0f + (Mathf.Pow(angleDiff, RotationSpeedScaler) / 180.0f);
-                float ratio = Mathf.Clamp01((speedScale * RotationDegreesPerSecond * Time.deltaTime) / angleDiff);
+                float ratio = Mathf.Clamp01((speedScale * RotationDegreesPerSecond * deltaTime) / angleDiff);
 
                 if (angleDiff < Mathf.Epsilon)
                 {
@@ -327,7 +334,7 @@ namespace HoloToolkit.Unity
 
                 float angleDiff = Quaternion.Angle(transform.localRotation, lerpTargetLocalRotation);
                 float speedScale = 1.0f + (Mathf.Pow(angleDiff, RotationSpeedScaler) / 180.0f);
-                float ratio = Mathf.Clamp01((speedScale * RotationDegreesPerSecond * Time.deltaTime) / angleDiff);
+                float ratio = Mathf.Clamp01((speedScale * RotationDegreesPerSecond * deltaTime) / angleDiff);
 
                 if (angleDiff < Mathf.Epsilon)
                 {
@@ -350,7 +357,7 @@ namespace HoloToolkit.Unity
                     lerpTargetLocalScale = Vector3.Lerp(transform.localScale, lerpTargetLocalScale, SmoothScaleLerpRatio);
                 }
 
-                Vector3 newScale = NonLinearInterpolateTo(transform.localScale, lerpTargetLocalScale, Time.deltaTime, ScalePerSecond);
+                Vector3 newScale = NonLinearInterpolateTo(transform.localScale, lerpTargetLocalScale, deltaTime, ScalePerSecond);
                 if ((targetLocalScale - newScale).sqrMagnitude <= smallNumber)
                 {
                     // Snap to final scale

--- a/Assets/HoloToolkit/Utilities/Scripts/Interpolator.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Interpolator.cs
@@ -264,7 +264,7 @@ namespace HoloToolkit.Unity
 
         public void Update()
         {
-            var deltaTime = UseUnscaledTime
+            float deltaTime = UseUnscaledTime
                 ? Time.unscaledDeltaTime
                 : Time.deltaTime;
 

--- a/Assets/HoloToolkit/Utilities/Scripts/SphereBasedTagalong.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/SphereBasedTagalong.cs
@@ -44,7 +44,7 @@ namespace HoloToolkit.Unity
             {
                 targetPosition = optimalPosition + offsetDir.normalized * SphereRadius;
 
-                var deltaTime = UseUnscaledTime
+                float deltaTime = UseUnscaledTime
                     ? Time.unscaledDeltaTime
                     : Time.deltaTime;
 

--- a/Assets/HoloToolkit/Utilities/Scripts/SphereBasedTagalong.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/SphereBasedTagalong.cs
@@ -17,6 +17,9 @@ namespace HoloToolkit.Unity
         [Tooltip("How fast the object will move to the target position.")]
         public float MoveSpeed = 2.0f;
 
+        [Tooltip("When moving, use unscaled time. This is useful for games that have a pause mechanism or otherwise adjust the game timescale.")]
+        public bool UseUnscaledTime = true;
+
         [Tooltip("Display the sphere in red wireframe for debugging purposes.")]
         public bool DebugDisplaySphere = false;
 
@@ -40,7 +43,12 @@ namespace HoloToolkit.Unity
             if (offsetDir.magnitude > SphereRadius)
             {
                 targetPosition = optimalPosition + offsetDir.normalized * SphereRadius;
-                this.transform.position = Vector3.Lerp(this.transform.position, targetPosition, MoveSpeed * Time.deltaTime);
+
+                var deltaTime = UseUnscaledTime
+                    ? Time.unscaledDeltaTime
+                    : Time.deltaTime;
+
+                this.transform.position = Vector3.Lerp(this.transform.position, targetPosition, MoveSpeed * deltaTime);
             }
         }
 

--- a/Assets/HoloToolkit/Utilities/Scripts/StabilizationPlaneModifier.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/StabilizationPlaneModifier.cs
@@ -102,7 +102,7 @@ namespace HoloToolkit.Unity
         {
             if (SetStabilizationPlane)
             {
-                var deltaTime = UseUnscaledTime
+                float deltaTime = UseUnscaledTime
                     ? Time.unscaledDeltaTime
                     : Time.deltaTime;
 

--- a/Assets/HoloToolkit/Utilities/Scripts/StabilizationPlaneModifier.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/StabilizationPlaneModifier.cs
@@ -14,8 +14,13 @@ namespace HoloToolkit.Unity
     {
         [Tooltip("Checking enables SetFocusPointForFrame to set the stabilization plane.")]
         public bool SetStabilizationPlane = true;
+
+        [Tooltip("When lerping, use unscaled time. This is useful for games that have a pause mechanism or otherwise adjust the game timescale.")]
+        public bool UseUnscaledTime = true;
+
         [Tooltip("Lerp speed when moving focus point closer.")]
         public float LerpStabilizationPlanePowerCloser = 4.0f;
+
         [Tooltip("Lerp speed when moving focus point farther away.")]
         public float LerpStabilizationPlanePowerFarther = 7.0f;
 
@@ -97,17 +102,21 @@ namespace HoloToolkit.Unity
         {
             if (SetStabilizationPlane)
             {
+                var deltaTime = UseUnscaledTime
+                    ? Time.unscaledDeltaTime
+                    : Time.deltaTime;
+
                 if (TargetOverride != null)
                 {
-                    ConfigureTransformOverridePlane();
+                    ConfigureTransformOverridePlane(deltaTime);
                 }
                 else if (UseGazeManager)
                 {
-                    ConfigureGazeManagerPlane();
+                    ConfigureGazeManagerPlane(deltaTime);
                 }
                 else
                 {
-                    ConfigureFixedDistancePlane();
+                    ConfigureFixedDistancePlane(deltaTime);
                 }
             }
         }
@@ -125,14 +134,14 @@ namespace HoloToolkit.Unity
         /// <summary>
         /// Configures the stabilization plane to update its position based on an object in the scene.        
         /// </summary>
-        private void ConfigureTransformOverridePlane()
+        private void ConfigureTransformOverridePlane(float deltaTime)
         {
             planePosition = TargetOverride.position;
 
             Vector3 velocity = Vector3.zero;
             if (TrackVelocity)
             {
-                velocity = UpdateVelocity();
+                velocity = UpdateVelocity(deltaTime);
             }
             
             // Place the plane at the desired depth in front of the user and billboard it to the gaze origin.
@@ -142,7 +151,7 @@ namespace HoloToolkit.Unity
         /// <summary>
         /// Configures the stabilization plane to update its position based on what your gaze intersects in the scene.
         /// </summary>
-        private void ConfigureGazeManagerPlane()
+        private void ConfigureGazeManagerPlane(float deltaTime)
         {
             Vector3 gazeOrigin = GazeManager.Instance.GazeOrigin;
             Vector3 gazeDirection = GazeManager.Instance.GazeNormal;
@@ -162,7 +171,7 @@ namespace HoloToolkit.Unity
                                                                         : LerpStabilizationPlanePowerCloser;
 
             // Smoothly move the focus point from previous hit position to new position.
-            currentPlaneDistance = Mathf.Lerp(currentPlaneDistance, focusPointDistance, lerpPower * Time.deltaTime);
+            currentPlaneDistance = Mathf.Lerp(currentPlaneDistance, focusPointDistance, lerpPower * deltaTime);
 
             planePosition = gazeOrigin + (gazeDirection * currentPlaneDistance);
 
@@ -172,13 +181,13 @@ namespace HoloToolkit.Unity
         /// <summary>
         /// Configures the stabilization plane to update based on a fixed distance away from you.
         /// </summary>
-        private void ConfigureFixedDistancePlane()
+        private void ConfigureFixedDistancePlane(float deltaTime)
         {
             float lerpPower = DefaultPlaneDistance > currentPlaneDistance ? LerpStabilizationPlanePowerFarther
                                                                           : LerpStabilizationPlanePowerCloser;
 
             // Smoothly move the focus point from previous hit position to new position.
-            currentPlaneDistance = Mathf.Lerp(currentPlaneDistance, DefaultPlaneDistance, lerpPower * Time.deltaTime);
+            currentPlaneDistance = Mathf.Lerp(currentPlaneDistance, DefaultPlaneDistance, lerpPower * deltaTime);
 
             planePosition = gazeManager.GazeOrigin + (gazeManager.GazeNormal * currentPlaneDistance);
             HolographicSettings.SetFocusPointForFrame(planePosition, -gazeManager.GazeNormal, Vector3.zero);
@@ -187,10 +196,10 @@ namespace HoloToolkit.Unity
         /// <summary>
         /// Tracks the velocity of the target object to be used as a hint for the plane stabilization.
         /// </summary>
-        private Vector3 UpdateVelocity()
+        private Vector3 UpdateVelocity(float deltaTime)
         {
             // Roughly calculate the velocity based on previous position, current position, and frame time.
-            Vector3 velocity = (TargetOverride.position - targetOverridePreviousPosition) / Time.deltaTime;
+            Vector3 velocity = (TargetOverride.position - targetOverridePreviousPosition) / deltaTime;
             targetOverridePreviousPosition = TargetOverride.position;
             return velocity;
         }


### PR DESCRIPTION
This change enables editor input, tagalongs, and the cursor to work
while the time scale is set to 0. Setting the time scale to 0 is a
common practice to implement game "pause" behavior as is done in the
Unity sample project. With this change, tagalong menus will still
function even when the game is paused.