### PR TITLE
Changed InputEnabled/Disabled in InputManager.cs to the standard Even…

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Cursor/AnimatedCursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/AnimatedCursor.cs
@@ -79,7 +79,7 @@ namespace HoloToolkit.Unity.InputModule
         /// <summary>
         /// Change anim stage when enabled
         /// </summary>
-        public override void OnInputEnabled()
+        protected override void OnInputEnabled()
         {
             base.OnInputEnabled();
             SetCursorState(EnableStateData);
@@ -88,7 +88,7 @@ namespace HoloToolkit.Unity.InputModule
         /// <summary>
         /// Change anim stage when disabled
         /// </summary>
-        public override void OnInputDisabled()
+        protected override void OnInputDisabled()
         {
             base.OnInputDisabled();
             SetCursorState(DisableStateData);

--- a/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using UnityEngine;
 
 namespace HoloToolkit.Unity.InputModule
@@ -217,8 +218,8 @@ namespace HoloToolkit.Unity.InputModule
                 OnInputDisabled();
             }
 
-            InputManager.Instance.InputEnabled += OnInputEnabled;
-            InputManager.Instance.InputDisabled += OnInputDisabled;
+            InputManager.Instance.InputEnabled += InputManager_InputEnabled;
+            InputManager.Instance.InputDisabled += InputManager_InputDisabled;
         }
 
         /// <summary>
@@ -234,9 +235,19 @@ namespace HoloToolkit.Unity.InputModule
             if (InputManager.Instance != null)
             {
                 InputManager.Instance.RemoveGlobalListener(gameObject);
-                InputManager.Instance.InputEnabled -= OnInputEnabled;
-                InputManager.Instance.InputDisabled -= OnInputDisabled;
+                InputManager.Instance.InputEnabled -= InputManager_InputEnabled;
+                InputManager.Instance.InputDisabled -= InputManager_InputDisabled;
             }
+        }
+
+        private void InputManager_InputEnabled(object sender, EventArgs e)
+        {
+            OnInputEnabled();
+        }
+
+        private void InputManager_InputDisabled(object sender, EventArgs e)
+        {
+            OnInputDisabled();
         }
 
         /// <summary>
@@ -322,7 +333,7 @@ namespace HoloToolkit.Unity.InputModule
         /// <summary>
         /// Disable input and set to contextual to override input
         /// </summary>
-        public virtual void OnInputDisabled()
+        protected virtual void OnInputDisabled()
         {
             // Reset visible hands on disable
             visibleHandsCount = 0;
@@ -334,7 +345,7 @@ namespace HoloToolkit.Unity.InputModule
         /// <summary>
         /// Enable input and set to none to reset cursor
         /// </summary>
-        public virtual void OnInputEnabled()
+        protected virtual void OnInputEnabled()
         {
             OnCursorStateChange(CursorStateEnum.None);
         }

--- a/Assets/HoloToolkit/Input/Scripts/InputManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputManager.cs
@@ -14,8 +14,8 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public class InputManager : Singleton<InputManager>
     {
-        public event Action InputEnabled;
-        public event Action InputDisabled;
+        public event EventHandler InputEnabled;
+        public event EventHandler InputDisabled;
 
         private readonly Stack<GameObject> modalInputStack = new Stack<GameObject>();
         private readonly Stack<GameObject> fallbackInputStack = new Stack<GameObject>();
@@ -130,7 +130,7 @@ namespace HoloToolkit.Unity.InputModule
 
             if (disabledRefCount == 1)
             {
-                InputDisabled.RaiseEvent();
+                InputDisabled.RaiseEvent(this, EventArgs.Empty);
             }
         }
 
@@ -145,7 +145,7 @@ namespace HoloToolkit.Unity.InputModule
 
             if (disabledRefCount == 0)
             {
-                InputEnabled.RaiseEvent();
+                InputEnabled.RaiseEvent(this, EventArgs.Empty);
             }
         }
 
@@ -159,7 +159,7 @@ namespace HoloToolkit.Unity.InputModule
 
             if (wasInputDisabled)
             {
-                InputEnabled.RaiseEvent();
+                InputEnabled.RaiseEvent(this, EventArgs.Empty);
             }
         }
 

--- a/Assets/HoloToolkit/Utilities/Scripts/Extensions/EventHandlerExtensions.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Extensions/EventHandlerExtensions.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+
+namespace HoloToolkit.Unity
+{
+    /// <summary>
+    /// Extensions for the EventHandler class.
+    /// These methods encapsulate the null check before raising an event.
+    /// </summary>
+    public static class EventHandlerExtensions
+    {
+        public static void RaiseEvent(this EventHandler handler, object sender, EventArgs e)
+        {
+            if (handler != null)
+            {
+                handler(sender, e);
+            }
+        }
+
+        public static void RaiseEvent<T>(this EventHandler<T> handler, object sender, T e) where T : EventArgs
+        {
+            if (handler != null)
+            {
+                handler(sender, e);
+            }
+        }
+    }
+}

--- a/Assets/HoloToolkit/Utilities/Scripts/Extensions/EventHandlerExtensions.cs.meta
+++ b/Assets/HoloToolkit/Utilities/Scripts/Extensions/EventHandlerExtensions.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 2ecf13b6fd80429408535ceb15e7f6a7
+timeCreated: 1483038520
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The events InputEnabled and InputDisabled in the InputManager were of type Action. Although allowed by C#, it's not the common pattern. This change doesn't add any EventArg allocation.

I also changed Cursor.cs to have event handlers calling the overridable methods. Changed these methods to protected as they should only be accessible by its descendants.