### PR TITLE
Wrapping code in #if UNITY_WSA for cross-platform support per #387

### DIFF
--- a/Assets/HoloToolkit-Examples/ColorPicker/GazeableColorPicker.cs
+++ b/Assets/HoloToolkit-Examples/ColorPicker/GazeableColorPicker.cs
@@ -1,4 +1,7 @@
-﻿using HoloToolkit.Unity.InputModule;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using HoloToolkit.Unity.InputModule;
 using UnityEngine;
 using UnityEngine.Events;
 
@@ -6,6 +9,7 @@ namespace Lighthouse
 {
     public class GazeableColorPicker : MonoBehaviour, IFocusable, IInputClickHandler
     {
+#if UNITY_WSA
         public Renderer rendererComponent;
 
         [System.Serializable]
@@ -50,5 +54,7 @@ namespace Lighthouse
         {
             UpdatePickedColor(OnPickedColor);
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit-Examples/GazeRuler/Scripts/DeleteLine.cs
+++ b/Assets/HoloToolkit-Examples/GazeRuler/Scripts/DeleteLine.cs
@@ -1,8 +1,12 @@
-﻿using UnityEngine;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
 using System.Collections;
 
 public class DeleteLine : MonoBehaviour
 {
+#if UNITY_WSA
     /// <summary>
     /// when tip text is tapped, destroy this tip and relative objects.
     /// </summary>
@@ -14,4 +18,5 @@ public class DeleteLine : MonoBehaviour
             Destroy(parent);
         }
     }
+#endif
 }

--- a/Assets/HoloToolkit-Examples/GazeRuler/Scripts/IGeometry.cs
+++ b/Assets/HoloToolkit-Examples/GazeRuler/Scripts/IGeometry.cs
@@ -1,4 +1,7 @@
-﻿using UnityEngine;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
 using System.Collections;
 
 /// <summary>
@@ -6,6 +9,7 @@ using System.Collections;
 /// </summary>
 public interface IGeometry
 {
+#if UNITY_WSA
     void AddPoint(GameObject LinePrefab, GameObject PointPrefab, GameObject TextPrefab);
 
     void Delete();
@@ -13,4 +17,6 @@ public interface IGeometry
     void Clear();
 
     void Reset();
+#endif
 }
+

--- a/Assets/HoloToolkit-Examples/GazeRuler/Scripts/IPolygonClosable.cs
+++ b/Assets/HoloToolkit-Examples/GazeRuler/Scripts/IPolygonClosable.cs
@@ -1,10 +1,16 @@
-﻿using UnityEngine;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
 
 /// <summary>
 /// any geometry class inherit this interface should be closeable
 /// </summary>
 public interface IPolygonClosable
 {
+#if UNITY_WSA
     //finish special ploygon
     void ClosePloygon(GameObject LinePrefab, GameObject TextPrefab);
+#endif
 }
+

--- a/Assets/HoloToolkit-Examples/GazeRuler/Scripts/LineManager.cs
+++ b/Assets/HoloToolkit-Examples/GazeRuler/Scripts/LineManager.cs
@@ -1,4 +1,7 @@
-﻿using UnityEngine;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
 using HoloToolkit.Unity;
 using System.Collections.Generic;
 using HoloToolkit.Unity.InputModule;
@@ -8,6 +11,7 @@ using HoloToolkit.Unity.InputModule;
 /// </summary>
 public class LineManager : Singleton<LineManager>, IGeometry
 {
+#if UNITY_WSA
     // save all lines in scene
     private Stack<Line> Lines = new Stack<Line>();
 
@@ -122,11 +126,13 @@ public class LineManager : Singleton<LineManager>, IGeometry
             lastPoint = null;
         }
     }
+#endif
 }
 
 
 public struct Line
 {
+#if UNITY_WSA
     public Vector3 Start { get; set; }
 
     public Vector3 End { get; set; }
@@ -134,4 +140,6 @@ public struct Line
     public GameObject Root { get; set; }
 
     public float Distance { get; set; }
+#endif
 }
+

--- a/Assets/HoloToolkit-Examples/GazeRuler/Scripts/MeasureManager.cs
+++ b/Assets/HoloToolkit-Examples/GazeRuler/Scripts/MeasureManager.cs
@@ -1,4 +1,7 @@
-﻿using UnityEngine;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
 using System.Collections;
 using HoloToolkit.Unity;
 using System.Collections.Generic;
@@ -10,6 +13,7 @@ using HoloToolkit.Unity.InputModule;
 /// </summary>
 public class MeasureManager : Singleton<MeasureManager>, IHoldHandler, IInputClickHandler
 {
+#if UNITY_WSA
     private IGeometry manager;
     public GeometryMode Mode;
 
@@ -103,22 +107,27 @@ public class MeasureManager : Singleton<MeasureManager>, IHoldHandler, IInputCli
     {
         OnSelect();
     }
+#endif
 }
 
 public class Point
 {
+#if UNITY_WSA
     public Vector3 Position { get; set; }
 
     public GameObject Root { get; set; }
     public bool IsStart { get; set; }
+#endif
 }
 
 
 public enum GeometryMode
 {
+#if UNITY_WSA
     Line,
     Triangle,
     Rectangle,
     Cube,
     Polygon
+#endif
 }

--- a/Assets/HoloToolkit-Examples/GazeRuler/Scripts/ModeTip.cs
+++ b/Assets/HoloToolkit-Examples/GazeRuler/Scripts/ModeTip.cs
@@ -1,4 +1,7 @@
-﻿using UnityEngine;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
 using HoloToolkit.Unity;
 
 /// <summary>
@@ -6,6 +9,7 @@ using HoloToolkit.Unity;
 /// </summary>
 public class ModeTip : Singleton<ModeTip>
 {
+#if UNITY_WSA
     private const string LineMode = "Line Mode";
     private const string PloygonMode = "Geometry Mode";
     private TextMesh text;
@@ -64,4 +68,6 @@ public class ModeTip : Singleton<ModeTip>
             }
         }
     }
+#endif
 }
+

--- a/Assets/HoloToolkit-Examples/GazeRuler/Scripts/PolygonManager.cs
+++ b/Assets/HoloToolkit-Examples/GazeRuler/Scripts/PolygonManager.cs
@@ -1,4 +1,7 @@
-﻿using UnityEngine;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
 using HoloToolkit.Unity;
 using System.Collections.Generic;
 using HoloToolkit.Unity.InputModule;
@@ -9,6 +12,7 @@ using HoloToolkit.Unity.InputModule;
 /// </summary>
 public class PolygonManager : Singleton<PolygonManager>, IGeometry, IPolygonClosable
 {
+#if UNITY_WSA
     // save all geometries
     public Stack<Ploygon> Ploygons = new Stack<Ploygon>();
     public Ploygon CurrentPloygon;
@@ -182,11 +186,13 @@ public class PolygonManager : Singleton<PolygonManager>, IGeometry, IPolygonClos
             };
         }
     }
+#endif
 }
 
 
 public class Ploygon
 {
+#if UNITY_WSA
     public float Area { get; set; }
 
     public List<Vector3> Points { get; set; }
@@ -195,5 +201,6 @@ public class Ploygon
 
     public bool IsFinished { get; set; }
 
+#endif
 }
 

--- a/Assets/HoloToolkit-Examples/GazeRuler/Scripts/Test/LineTest.cs
+++ b/Assets/HoloToolkit-Examples/GazeRuler/Scripts/Test/LineTest.cs
@@ -1,4 +1,7 @@
-﻿using UnityEngine;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
 using System.Collections;
 
 /// <summary>
@@ -6,6 +9,7 @@ using System.Collections;
 /// </summary>
 public class LineTest : MonoBehaviour
 {
+#if UNITY_WSA
 
     public GameObject start;
     public GameObject end;
@@ -28,4 +32,6 @@ public class LineTest : MonoBehaviour
 
         Debug.Log(Vector3.Angle(direction, Vector3.forward));
     }
+#endif
 }
+

--- a/Assets/HoloToolkit-Examples/SharingWithUNET/Scripts/BulletController.cs
+++ b/Assets/HoloToolkit-Examples/SharingWithUNET/Scripts/BulletController.cs
@@ -10,6 +10,7 @@ namespace HoloToolkit.Examples.SharingWithUNET
     /// </summary>
     public class BulletController : MonoBehaviour
     {
+#if UNITY_WSA
         private void Start()
         {
             // The bullet's transform should be in local space to the Shared Anchor.
@@ -22,5 +23,6 @@ namespace HoloToolkit.Examples.SharingWithUNET
             Rigidbody rb = GetComponentInChildren<Rigidbody>();
             rb.velocity = transform.parent.TransformDirection(rb.velocity);
         }
-    }
+#endif
+	}
 }

--- a/Assets/HoloToolkit-Examples/SharingWithUNET/Scripts/GenericNetworkTransmitter.cs
+++ b/Assets/HoloToolkit-Examples/SharingWithUNET/Scripts/GenericNetworkTransmitter.cs
@@ -18,6 +18,7 @@ using System;
 /// </summary>
 public class GenericNetworkTransmitter : Singleton<GenericNetworkTransmitter>
 {
+#if UNITY_WSA
 
     [Tooltip("The connection port on the machine to use.")]
     public int SendConnectionPort = 11000;
@@ -212,4 +213,6 @@ public class GenericNetworkTransmitter : Singleton<GenericNetworkTransmitter>
     }
     private void ConnectListener() {}
 #endif
+#endif
 }
+

--- a/Assets/HoloToolkit-Examples/SharingWithUNET/Scripts/NetworkDiscoveryWithAnchors.cs
+++ b/Assets/HoloToolkit-Examples/SharingWithUNET/Scripts/NetworkDiscoveryWithAnchors.cs
@@ -14,6 +14,7 @@ using UnityEngine.Networking;
 /// </summary>
 public class NetworkDiscoveryWithAnchors : NetworkDiscovery
 {
+#if UNITY_WSA
     /// <summary>
     /// This flag gets set when we recieve a broadcast.
     /// if this flag is set then we should not create a server.
@@ -149,4 +150,6 @@ public class NetworkDiscoveryWithAnchors : NetworkDiscovery
         // And join the networked experience as a client.
         NetworkManager.singleton.StartClient();
     }
+#endif
 }
+

--- a/Assets/HoloToolkit-Examples/SharingWithUNET/Scripts/PlayerController.cs
+++ b/Assets/HoloToolkit-Examples/SharingWithUNET/Scripts/PlayerController.cs
@@ -13,6 +13,7 @@ namespace HoloToolkit.Examples.SharingWithUNET
     [NetworkSettings(sendInterval = 0.033f)]
     public class PlayerController : NetworkBehaviour, IInputClickHandler
     {
+#if UNITY_WSA
         /// <summary>
         /// The game object that represents the 'bullet' for 
         /// this player. Must exist in the spawnable prefabs on the
@@ -138,5 +139,7 @@ namespace HoloToolkit.Examples.SharingWithUNET
                 CmdFire();
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit-Examples/SharingWithUNET/Scripts/SharedAnchorDebugText.cs
+++ b/Assets/HoloToolkit-Examples/SharingWithUNET/Scripts/SharedAnchorDebugText.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
+
 using UnityEngine;
 
 /// <summary>
 /// It is nice to know what is going on with the networking scene sometimes.
 /// </summary>
 public class SharedAnchorDebugText : MonoBehaviour {
+#if UNITY_WSA
 
     /// <summary>
     /// Set in the editor with the network discovery object since
@@ -115,4 +117,5 @@ public class SharedAnchorDebugText : MonoBehaviour {
             anchorEstablished ? "Anchored Here\n": (wasImporting  ? "Importing\n" : (wasDownloading ? "Downloading\n" : "Not Anchored\n")),
             anchorName);
     }
+#endif
 }

--- a/Assets/HoloToolkit-Examples/SharingWithUNET/Scripts/SharedCollection.cs
+++ b/Assets/HoloToolkit-Examples/SharingWithUNET/Scripts/SharedCollection.cs
@@ -9,5 +9,7 @@ using HoloToolkit.Unity;
 /// </summary>
 public class SharedCollection : Singleton<SharedCollection>
 {
-	
+#if UNITY_WSA
+#endif	
 }
+

--- a/Assets/HoloToolkit-Examples/SharingWithUNET/Scripts/UNetAnchorManager.cs
+++ b/Assets/HoloToolkit-Examples/SharingWithUNET/Scripts/UNetAnchorManager.cs
@@ -15,6 +15,7 @@ using System;
 /// </summary>
 public class UNetAnchorManager : NetworkBehaviour
 {
+#if UNITY_WSA
     /// <summary>
     ///  Since we aren't a MonoBehavior we can't just use the singleton class
     ///  so we'll reroll it as a one off here.
@@ -299,4 +300,6 @@ public class UNetAnchorManager : NetworkBehaviour
             CreateAnchor();
         }
     }
+#endif
 }
+

--- a/Assets/HoloToolkit-Examples/SpatialMappingComponent/DropCube.cs
+++ b/Assets/HoloToolkit-Examples/SpatialMappingComponent/DropCube.cs
@@ -1,4 +1,7 @@
-﻿using UnityEngine;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
 using UnityEngine.VR.WSA.Input;
 
 /// <summary>
@@ -6,6 +9,7 @@ using UnityEngine.VR.WSA.Input;
 /// </summary>
 public class DropCube : MonoBehaviour
 {
+#if UNITY_WSA
     GestureRecognizer recognizer;
 
     void Start ()
@@ -28,4 +32,5 @@ public class DropCube : MonoBehaviour
         cube.transform.position = Camera.main.transform.position + Camera.main.transform.forward; // Start to drop it in front of the camera
         cube.AddComponent<Rigidbody>(); // Apply physics
     }
+#endif
 }

--- a/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/AppState.cs
+++ b/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/AppState.cs
@@ -9,6 +9,7 @@ using HoloToolkit.Unity.SpatialMapping;
 
 public class AppState : Singleton<AppState>, ISourceStateHandler, IInputClickHandler
 {
+#if UNITY_WSA
     // Consts
     public float kMinAreaForStats = 5.0f;
     public float kMinAreaForComplete = 50.0f;
@@ -261,4 +262,6 @@ public class AppState : Singleton<AppState>, ISourceStateHandler, IInputClickHan
             SpatialUnderstanding.Instance.RequestFinishScan();
         }
     }
+#endif
 }
+

--- a/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/LevelSolver.cs
+++ b/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/LevelSolver.cs
@@ -10,6 +10,7 @@ using System;
 
 public class LevelSolver : LineDrawer
 {
+#if UNITY_WSA
     // Singleton
     public static LevelSolver Instance;
 
@@ -500,4 +501,6 @@ public class LevelSolver : LineDrawer
         // Lines: Finish up
         LineDraw_End(needsUpdate);
     }
+#endif
 }
+

--- a/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/LineDrawer.cs
+++ b/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/LineDrawer.cs
@@ -9,6 +9,7 @@ using System;
 
 public class LineDrawer : MonoBehaviour
 {
+#if UNITY_WSA
     // Consts
     public const float DefaultLineWidth = 0.001f;
     public const float DefaultBasisLength = 0.2f;
@@ -469,4 +470,5 @@ public class LineDrawer : MonoBehaviour
             Lines_LineDataToMesh();
         }
     }
+#endif
 }

--- a/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/ShapeDefinition.cs
+++ b/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/ShapeDefinition.cs
@@ -9,6 +9,7 @@ using System.Collections.ObjectModel;
 
 public class ShapeDefinition : Singleton<ShapeDefinition>
 {
+#if UNITY_WSA
     // Properties
     public bool HasCreatedShapes { get; private set; }
     public ReadOnlyCollection<string> CustomShapeDefinitions { get { return customShapeDefinitions.AsReadOnly(); } }
@@ -212,4 +213,6 @@ public class ShapeDefinition : Singleton<ShapeDefinition>
         // Mark it
         HasCreatedShapes = true;
     }
+#endif
 }
+

--- a/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/SpaceVisualizer.cs
+++ b/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/SpaceVisualizer.cs
@@ -11,6 +11,7 @@ using HoloToolkit.Unity;
 
 public class SpaceVisualizer : LineDrawer
 {
+#if UNITY_WSA
     // Singleton
     public static SpaceVisualizer Instance;
 
@@ -421,4 +422,6 @@ public class SpaceVisualizer : LineDrawer
         // Lines: Finish up
         LineDraw_End(needsUpdate);
     }
+#endif
 }
+

--- a/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/SpatialUnderstandingBasicCursor.cs
+++ b/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/SpatialUnderstandingBasicCursor.cs
@@ -11,6 +11,7 @@ using UnityEngine;
 /// </summary>
 public class SpatialUnderstandingBasicCursor : MonoBehaviour
 {
+#if UNITY_WSA
     public struct RaycastResult
     {
         public bool Hit;
@@ -89,4 +90,5 @@ public class SpatialUnderstandingBasicCursor : MonoBehaviour
         gameObject.transform.up = rayResult.Normal;
         gameObject.transform.rotation *= cursorDefaultRotation;
     }
+#endif
 }

--- a/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/SpatialUnderstandingCursor.cs
+++ b/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/SpatialUnderstandingCursor.cs
@@ -13,6 +13,7 @@ using Button = UnityEngine.UI.Button;
 
 public class SpatialUnderstandingCursor : SpatialUnderstandingBasicCursor
 {
+#if UNITY_WSA
     // Consts
     public const float RayCastLength = 10.0f;
 
@@ -157,4 +158,6 @@ public class SpatialUnderstandingCursor : SpatialUnderstandingBasicCursor
         float textAlpha = RayCastUI(out hitPos, out hitNormal, out hitButton) ? 0.15f : 1.0f;
         CursorText.color = new Color(1.0f, 1.0f, 1.0f, textAlpha);
     }
+#endif
 }
+

--- a/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/UI.cs
+++ b/Assets/HoloToolkit-Examples/SpatialUnderstanding/SpatialUnderstanding-FeatureOverview/Scripts/UI.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 
 public class UI : LineDrawer
 {
+#if UNITY_WSA
     // Consts
     public const float MenuWidth = 1.5f;
     public const float MenuHeight = 1.0f;
@@ -319,4 +320,6 @@ public class UI : LineDrawer
             }
         }
     }
+#endif
 }
+

--- a/Assets/HoloToolkit/Build/Editor/BuildDeployPortal.cs
+++ b/Assets/HoloToolkit/Build/Editor/BuildDeployPortal.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-//
 
 using UnityEngine;
 using System.Collections;
@@ -17,6 +15,7 @@ namespace HoloToolkit.Unity
     /// </summary>
     public class BuildDeployPortal
     {
+#if UNITY_WSA
         // Consts
         public const float TimeOut = 6.0f;
         public const int TimeoutMS = (int)(TimeOut * 1000.0f);
@@ -442,5 +441,7 @@ namespace HoloToolkit.Unity
             string returnValue = System.Text.ASCIIEncoding.ASCII.GetString(encodedDataAsBytes);
             return returnValue;
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Build/Editor/BuildDeployPrefs.cs
+++ b/Assets/HoloToolkit/Build/Editor/BuildDeployPrefs.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-//
 
 using System.IO;
 using UnityEditor;
@@ -12,6 +10,7 @@ namespace HoloToolkit.Unity
 
     public static class BuildDeployPrefs
     {
+#if UNITY_WSA
         // Constants
         private const string EditorPrefs_BuildDir = "BuildDeployWindow_BuildDir";
         private const string EditorPrefs_BuildConfig = "BuildDeployWindow_BuildConfig";
@@ -98,5 +97,7 @@ namespace HoloToolkit.Unity
                 return defaultValue;
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Build/Editor/BuildDeployTools.cs
+++ b/Assets/HoloToolkit/Build/Editor/BuildDeployTools.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-//
 
 using System;
 using System.IO;
@@ -19,6 +17,7 @@ namespace HoloToolkit.Unity
     /// </summary>
     public class BuildDeployTools
     {
+#if UNITY_WSA
         // Consts
         public static readonly string DefaultMSBuildVersion = "14.0";
 
@@ -183,5 +182,7 @@ namespace HoloToolkit.Unity
             versionAttr.Value = newVersion.ToString();
             rootNode.Save(manifest);
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Build/Editor/BuildDeployWindow.cs
+++ b/Assets/HoloToolkit/Build/Editor/BuildDeployWindow.cs
@@ -3,6 +3,7 @@
 // Copyright (c) Rafael Rivera
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 //
+#if UNITY_WSA
 
 using System.IO;
 using System.Collections.Generic;
@@ -717,3 +718,5 @@ namespace HoloToolkit.Unity
         }
     }
 }
+
+#endif

--- a/Assets/HoloToolkit/Build/Editor/BuildSLNUtilities.cs
+++ b/Assets/HoloToolkit/Build/Editor/BuildSLNUtilities.cs
@@ -1,7 +1,5 @@
-//
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-//
 
 using System;
 using System.Collections.Generic;
@@ -19,6 +17,7 @@ namespace HoloToolkit.Unity
     /// </summary>
     public static class BuildSLNUtilities
     {
+#if UNITY_WSA
         public class CopyDirectoryInfo
         {
             public string Source { get; set; }
@@ -513,5 +512,7 @@ namespace HoloToolkit.Unity
         {
             return Path.GetDirectoryName(Path.GetFullPath(Application.dataPath));
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Build/Editor/HoloToolkitCommands.cs
+++ b/Assets/HoloToolkit/Build/Editor/HoloToolkitCommands.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-//
 
 using HoloToolkit.Unity;
 
@@ -10,6 +8,7 @@ using HoloToolkit.Unity;
 /// </summary>
 public static class HoloToolkitCommands
 {
+#if UNITY_WSA
     /// <summary>
     /// Do a build configured for the HoloLens, returns the error from BuildPipeline.BuildPlayer
     /// </summary>
@@ -17,4 +16,6 @@ public static class HoloToolkitCommands
     {
         return BuildDeployTools.BuildSLN(BuildDeployPrefs.BuildDirectory, false);
     }
+#endif
 }
+

--- a/Assets/HoloToolkit/Build/Editor/XdeGuestLocator.cs
+++ b/Assets/HoloToolkit/Build/Editor/XdeGuestLocator.cs
@@ -1,8 +1,6 @@
-﻿//
-// Copyright (c) Microsoft Corporation
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Copyright (c) Rafael Rivera
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-//
 
 using System;
 using System.Linq;
@@ -16,6 +14,7 @@ namespace HoloToolkit.Unity
 {
     public static class XdeGuestLocator
     {
+#if UNITY_WSA
         [StructLayout(LayoutKind.Sequential, Pack = 4)]
         struct XdePeerHostIdentifier
         {
@@ -146,5 +145,7 @@ namespace HoloToolkit.Unity
 
             return bytes;
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/CrossPlatform/Scripts/MetroHandleRef.cs
+++ b/Assets/HoloToolkit/CrossPlatform/Scripts/MetroHandleRef.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#if UNITY_METRO && !UNITY_EDITOR
+#if UNITY_WSA && !UNITY_EDITOR
 
 using System;
 

--- a/Assets/HoloToolkit/CrossPlatform/Scripts/Reflection/ReflectionExtensions.cs
+++ b/Assets/HoloToolkit/CrossPlatform/Scripts/Reflection/ReflectionExtensions.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#if UNITY_METRO && !UNITY_EDITOR
+#if UNITY_WSA && !UNITY_EDITOR
 
 using System;
 using System.Collections.Generic;
@@ -190,3 +190,4 @@ public static class ReflectionExtensions
 }
 
 #endif
+

--- a/Assets/HoloToolkit/CrossPlatform/Scripts/Reflection/TypeUtils.cs
+++ b/Assets/HoloToolkit/CrossPlatform/Scripts/Reflection/TypeUtils.cs
@@ -9,6 +9,7 @@ using System.Text;
 
 public static class TypeUtils
 {
+#if UNITY_WSA
     public static Type GetBaseType(this Type type)
     {
 #if UNITY_METRO && !UNITY_EDITOR
@@ -17,4 +18,6 @@ public static class TypeUtils
         return type.BaseType;
 #endif
     }
+#endif
 }
+

--- a/Assets/HoloToolkit/CrossPlatform/Scripts/SystemException.cs
+++ b/Assets/HoloToolkit/CrossPlatform/Scripts/SystemException.cs
@@ -6,9 +6,12 @@ namespace System
 {
     public class SystemException : Exception
     {
+#if UNITY_WSA
         public SystemException() {}
         public SystemException(string message) : base(message) {}
         public SystemException(string message, Exception innerException) : base(message, innerException) {}
+#endif
     }
 }
 #endif
+

--- a/Assets/HoloToolkit/Input/Scripts/Cursor/AnimatedCursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/AnimatedCursor.cs
@@ -12,6 +12,7 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public class AnimatedCursor : Cursor
     {
+#if UNITY_WSA
         /// <summary>
         /// Data struct for cursor state information for the Animated Cursor, which leverages the Unity animation system..
         /// This defines a modification to an Unity animation parameter, based on cursor state.
@@ -165,6 +166,8 @@ namespace HoloToolkit.Unity.InputModule
             }
         }
 
+#endif
     }
 
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
@@ -10,7 +10,8 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public abstract class Cursor : MonoBehaviour, ICursor
     {
-        /// <summary>
+ #if UNITY_WSA
+       /// <summary>
         /// Enum for current cursor state
         /// </summary>
         public enum CursorStateEnum
@@ -436,5 +437,7 @@ namespace HoloToolkit.Unity.InputModule
         {
             cursorState = state;
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/Cursor/CursorModifier.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/CursorModifier.cs
@@ -11,6 +11,7 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public class CursorModifier : MonoBehaviour, ICursorModifier
     {
+#if UNITY_WSA
         [Tooltip("Transform for which this cursor modifier applies its various properties.")]
         public Transform HostTransform;
 
@@ -102,5 +103,7 @@ namespace HoloToolkit.Unity.InputModule
             rotation = GetModifiedRotation(cursor);
             scale = GetModifiedScale(cursor);
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/Cursor/ICursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/ICursor.cs
@@ -10,6 +10,7 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public interface ICursor : IInputHandler, IInputClickHandler, ISourceStateHandler
     {
+#if UNITY_WSA
         /// <summary>
         /// Position of the cursor.
         /// </summary>
@@ -30,5 +31,7 @@ namespace HoloToolkit.Unity.InputModule
         /// </summary>
         /// <param name="visible">True if cursor should be visible, false if not.</param>
         void SetVisiblity(bool visible);
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/Cursor/ICursorModifier.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/ICursorModifier.cs
@@ -10,6 +10,7 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public interface ICursorModifier
     {
+#if UNITY_WSA
         /// <summary>
         /// Indicates whether the cursor should be visible or not.
         /// </summary>
@@ -45,5 +46,7 @@ namespace HoloToolkit.Unity.InputModule
         /// <param name="rotation">Modified rotation.</param>
         /// <param name="scale">Modified scale.</param>
         void GetModifiedTransform(ICursor cursor, out Vector3 position, out Quaternion rotation, out Vector3 scale);
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/Cursor/MeshCursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/MeshCursor.cs
@@ -11,6 +11,7 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public class MeshCursor : Cursor
     {
+#if UNITY_WSA
         [Serializable]
         public struct MeshCursorDatum
         {
@@ -82,5 +83,7 @@ namespace HoloToolkit.Unity.InputModule
                 TargetRenderer.transform.localScale = stateDatum.LocalScale;
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/Cursor/ObjectCursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/ObjectCursor.cs
@@ -12,6 +12,7 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public class ObjectCursor : Cursor
     {
+#if UNITY_WSA
         [Serializable]
         public struct ObjectCursorDatum
         {
@@ -67,5 +68,7 @@ namespace HoloToolkit.Unity.InputModule
                 }
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/Cursor/SpriteCursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/SpriteCursor.cs
@@ -11,6 +11,7 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public class SpriteCursor : Cursor
     {
+#if UNITY_WSA
         [Serializable]
         public struct SpriteCursorDatum
         {
@@ -76,6 +77,8 @@ namespace HoloToolkit.Unity.InputModule
             }
         }
 
+#endif
     }
 
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/GameControllerManipulator.cs
+++ b/Assets/HoloToolkit/Input/Scripts/GameControllerManipulator.cs
@@ -1,4 +1,7 @@
-﻿using UnityEngine;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
 
 namespace HoloToolkit.Unity.InputModule
 {
@@ -9,6 +12,7 @@ namespace HoloToolkit.Unity.InputModule
     /// <remarks>Make sure to enable the HumanInterfaceDevice capability before using.</remarks>
     public class GameControllerManipulator : MonoBehaviour
     {
+#if UNITY_WSA
         [Tooltip("Name of the joystick axis that moves the object along X as set in InputManager")]
         public string MoveXAxisName = "ControllerLeftStickX";
         [Tooltip("Speed of movement along X")]
@@ -157,5 +161,7 @@ namespace HoloToolkit.Unity.InputModule
             objectToRotate.transform.rotation = Quaternion.Euler(vectorToRotateAround * result) * objectToRotate.transform.rotation;
             return result;
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/Gaze/BaseRayStabilizer.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Gaze/BaseRayStabilizer.cs
@@ -11,6 +11,7 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public abstract class BaseRayStabilizer : MonoBehaviour
     {
+#if UNITY_WSA
         /// <summary>
         /// The stabilized position.
         /// </summary>
@@ -32,5 +33,7 @@ namespace HoloToolkit.Unity.InputModule
         /// <param name="position">Input position to smooth.</param>
         /// <param name="rotation">Input orientation to smooth.</param>
         public abstract void UpdateStability(Vector3 position, Quaternion rotation);
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
@@ -12,6 +12,7 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public class GazeManager : Singleton<GazeManager>
     {
+#if UNITY_WSA
         public delegate void FocusedChangedDelegate(GameObject previousObject, GameObject newObject);
 
         /// <summary>
@@ -367,5 +368,7 @@ namespace HoloToolkit.Unity.InputModule
         }
 
         #endregion Helpers
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/Gaze/GazeStabilizer.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Gaze/GazeStabilizer.cs
@@ -11,6 +11,7 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public class GazeStabilizer : BaseRayStabilizer
     {
+#if UNITY_WSA
         [Tooltip("Number of samples that you want to iterate on.")]
         [Range(40, 120)]
         public int StoredStabilitySamples = 60;
@@ -111,5 +112,7 @@ namespace HoloToolkit.Unity.InputModule
             stableRotation = Quaternion.LookRotation(Vector3.Lerp(stableRotation * Vector3.forward, gazeDirection, lerpPower));
             stableRay = new Ray(stablePosition, stableRotation * Vector3.forward);
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/HandGuidance.cs
+++ b/Assets/HoloToolkit/Input/Scripts/HandGuidance.cs
@@ -11,6 +11,7 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public class HandGuidance : Singleton<HandGuidance>
     {
+#if UNITY_WSA
         [Tooltip("The Cursor object the HandGuidanceIndicator will be positioned around.")]
         public GameObject Cursor;
 
@@ -165,5 +166,7 @@ namespace HoloToolkit.Unity.InputModule
 
             base.OnDestroy();
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/InputEvents/BaseInputEventData.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputEvents/BaseInputEventData.cs
@@ -32,3 +32,4 @@ namespace HoloToolkit.Unity.InputModule
         }
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/InputEvents/IFocusable.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputEvents/IFocusable.cs
@@ -10,7 +10,10 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public interface IFocusable : IEventSystemHandler
     {
+#if UNITY_WSA
         void OnFocusEnter();
         void OnFocusExit();
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/InputEvents/IHoldHandler.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputEvents/IHoldHandler.cs
@@ -10,8 +10,11 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public interface IHoldHandler : IEventSystemHandler
     {
+#if UNITY_WSA
         void OnHoldStarted(HoldEventData eventData);
         void OnHoldCompleted(HoldEventData eventData);
         void OnHoldCanceled(HoldEventData eventData);
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/InputEvents/IInputClickHandler.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputEvents/IInputClickHandler.cs
@@ -10,6 +10,9 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public interface IInputClickHandler : IEventSystemHandler
     {
+#if UNITY_WSA
         void OnInputClicked(InputEventData eventData);
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/InputEvents/IInputHandler.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputEvents/IInputHandler.cs
@@ -10,7 +10,10 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public interface IInputHandler : IEventSystemHandler
     {
+#if UNITY_WSA
         void OnInputUp(InputEventData eventData);
         void OnInputDown(InputEventData eventData);
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/InputEvents/IManipulationHandler.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputEvents/IManipulationHandler.cs
@@ -10,9 +10,12 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public interface IManipulationHandler : IEventSystemHandler
     {
+#if UNITY_WSA
         void OnManipulationStarted(ManipulationEventData eventData);
         void OnManipulationUpdated(ManipulationEventData eventData);
         void OnManipulationCompleted(ManipulationEventData eventData);
         void OnManipulationCanceled(ManipulationEventData eventData);
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/InputEvents/INavigationHandler.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputEvents/INavigationHandler.cs
@@ -10,9 +10,12 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public interface INavigationHandler : IEventSystemHandler
     {
+#if UNITY_WSA
         void OnNavigationStarted(NavigationEventData eventData);
         void OnNavigationUpdated(NavigationEventData eventData);
         void OnNavigationCompleted(NavigationEventData eventData);
         void OnNavigationCanceled(NavigationEventData eventData);
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/InputEvents/ISourceStateHandler.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputEvents/ISourceStateHandler.cs
@@ -10,7 +10,10 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public interface ISourceStateHandler : IEventSystemHandler
     {
+#if UNITY_WSA
         void OnSourceDetected(SourceStateEventData eventData);
         void OnSourceLost(SourceStateEventData eventData);
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/InputEvents/ISpeechHandler.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputEvents/ISpeechHandler.cs
@@ -10,6 +10,9 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public interface ISpeechHandler : IEventSystemHandler
     {
+#if UNITY_WSA
         void OnSpeechKeywordRecognized(SpeechKeywordRecognizedEventData eventData);
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/InputEvents/InputEventData.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputEvents/InputEventData.cs
@@ -20,3 +20,4 @@ namespace HoloToolkit.Unity.InputModule
         }
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/InputEvents/ManipulationEventData.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputEvents/ManipulationEventData.cs
@@ -28,3 +28,4 @@ namespace HoloToolkit.Unity.InputModule
         }
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/InputEvents/NavigationEventData.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputEvents/NavigationEventData.cs
@@ -28,3 +28,4 @@ namespace HoloToolkit.Unity.InputModule
         }
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/InputEvents/SourceStateEventData.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputEvents/SourceStateEventData.cs
@@ -20,3 +20,4 @@ namespace HoloToolkit.Unity.InputModule
         }
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/InputEvents/SpeechKeywordRecognizedEventData.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputEvents/SpeechKeywordRecognizedEventData.cs
@@ -53,3 +53,4 @@ namespace HoloToolkit.Unity.InputModule
         }
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/InputManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputManager.cs
@@ -14,6 +14,7 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public class InputManager : Singleton<InputManager>
     {
+#if UNITY_WSA
         public event Action InputEnabled;
         public event Action InputDisabled;
 
@@ -673,5 +674,7 @@ namespace HoloToolkit.Unity.InputModule
             // Pass handler through HandleEvent to perform modal/fallback logic
             HandleEvent(speechKeywordRecognizedEventData, OnSpeechKeywordRecognizedEventHandler);
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/InputSources/BaseInputSource.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputSources/BaseInputSource.cs
@@ -11,6 +11,7 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public abstract class BaseInputSource : MonoBehaviour, IInputSource
     {
+#if UNITY_WSA
         public event EventHandler<InputSourceEventArgs> SourceUp;
         public event EventHandler<InputSourceEventArgs> SourceDown;
         public event EventHandler<SourceClickEventArgs> SourceClicked;
@@ -262,5 +263,7 @@ namespace HoloToolkit.Unity.InputModule
         }
 
         #endregion
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/InputSources/EditorHandsInput.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputSources/EditorHandsInput.cs
@@ -15,6 +15,7 @@ namespace HoloToolkit.Unity.InputModule
     [RequireComponent(typeof(ManualHandControl))]
     public class EditorHandsInput : BaseInputSource
     {
+#if UNITY_WSA
         /// <summary>
         /// Data for a hand.
         /// </summary>
@@ -345,5 +346,7 @@ namespace HoloToolkit.Unity.InputModule
             }
             pendingHandIdDeletes.Clear();
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/InputSources/GesturesInput.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputSources/GesturesInput.cs
@@ -12,6 +12,7 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public class GesturesInput : BaseInputSource
     {
+#if UNITY_WSA
         [Tooltip("Set to true to use the use rails (guides) for the navigation gesture, as opposed to full 3D navigation.")]
         public bool UseRailsNavigation = false;
 
@@ -181,5 +182,7 @@ namespace HoloToolkit.Unity.InputModule
         {
             return SupportedInputInfo.None;
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/InputSources/IInputSource.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputSources/IInputSource.cs
@@ -37,6 +37,7 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public interface IInputSource
     {
+#if UNITY_WSA
         /// <summary>
         /// Event triggered when the input source goes up. This is the equivalent of the pointer up event of a mouse.
         /// </summary>
@@ -158,5 +159,7 @@ namespace HoloToolkit.Unity.InputModule
         /// <param name="orientation">Out parameter filled with the orientation if available, otherwise the zero vector.</param>
         /// <returns>True if an orientation was retrieved, false if not.</returns>
         bool TryGetOrientation(uint sourceId, out Quaternion orientation);
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/InputSources/InputSourceEventArgs.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputSources/InputSourceEventArgs.cs
@@ -11,6 +11,7 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public class InputSourceEventArgs : EventArgs
     {
+#if UNITY_WSA
         /// <summary>
         /// Input source that triggered the event.
         /// </summary>
@@ -90,5 +91,7 @@ namespace HoloToolkit.Unity.InputModule
         {
             NormalizedOffset = normalizedOffset;
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/InputSources/RawInteractionSourcesInput.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputSources/RawInteractionSourcesInput.cs
@@ -19,6 +19,7 @@ namespace HoloToolkit.Unity.InputModule
     /// </remarks>
     public class RawInteractionSourcesInput : BaseInputSource
     {
+#if UNITY_WSA
         /// <summary>
         /// Data for an interaction source.
         /// </summary>
@@ -241,5 +242,7 @@ namespace HoloToolkit.Unity.InputModule
             }
             pendingSourceIdDeletes.Clear();
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/InputSources/SpeechKeywordRecognizedEventArgs.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputSources/SpeechKeywordRecognizedEventArgs.cs
@@ -12,6 +12,7 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public class SpeechKeywordRecognizedEventArgs : InputSourceEventArgs
     {
+#if UNITY_WSA
         /// <summary>
         /// A measure of correct recognition certainty.
         /// </summary>
@@ -45,5 +46,7 @@ namespace HoloToolkit.Unity.InputModule
             SemanticMeanings = semanticMeanings;
             RecognizedText = recognizedText;
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/Interactions/HandDraggable.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Interactions/HandDraggable.cs
@@ -16,6 +16,7 @@ namespace HoloToolkit.Unity.InputModule
                                  IInputHandler,
                                  ISourceStateHandler
     {
+#if UNITY_WSA
         /// <summary>
         /// Event triggered when dragging starts.
         /// </summary>
@@ -299,5 +300,7 @@ namespace HoloToolkit.Unity.InputModule
                 StopDragging();
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/KeyboardManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/KeyboardManager.cs
@@ -12,6 +12,7 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public class KeyboardManager : Singleton<KeyboardManager>
     {
+#if UNITY_WSA
         public enum KeyEvent
         {
             /// <summary>
@@ -233,5 +234,7 @@ namespace HoloToolkit.Unity.InputModule
             }
         }
         #endregion
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/Microphone/MicStream.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Microphone/MicStream.cs
@@ -9,6 +9,7 @@ namespace HoloToolkit.Unity.InputModule
 {
     public class MicStream
     {
+#if UNITY_WSA
         // This class replaces Unity's Microphone object
         // This class is made for HoloLens mic stream selection, but should work well on all windows 10 devices
         // chooses from one of three possible microphone modes on HoloLens
@@ -191,5 +192,7 @@ namespace HoloToolkit.Unity.InputModule
             }
             return true;
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/SetGlobalListener.cs
+++ b/Assets/HoloToolkit/Input/Scripts/SetGlobalListener.cs
@@ -10,9 +10,12 @@ namespace HoloToolkit.Unity.InputModule.Tests
     /// </summary>
     public class SetGlobalListener : MonoBehaviour
     {
+#if UNITY_WSA
         private void Start()
         {
             InputManager.Instance.AddGlobalListener(gameObject);
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/UI/TriggerButton.cs
+++ b/Assets/HoloToolkit/Input/Scripts/UI/TriggerButton.cs
@@ -11,6 +11,7 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public class TriggerButton : MonoBehaviour, IInputClickHandler
     {
+#if UNITY_WSA
         /// <summary>
         /// Indicates whether the button is clickable or not.
         /// </summary>
@@ -37,5 +38,7 @@ namespace HoloToolkit.Unity.InputModule
                 ButtonPressed.RaiseEvent();
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/AxisController.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/AxisController.cs
@@ -14,6 +14,7 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public class AxisController : MonoBehaviour
     {
+#if UNITY_WSA
         /// <summary>
         /// Type of input axis, based on device.
         /// </summary>
@@ -553,6 +554,8 @@ namespace HoloToolkit.Unity.InputModule
             return false;
         }
 #endif
+#endif
     }
 
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/ButtonController.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/ButtonController.cs
@@ -12,6 +12,7 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public class ButtonController : MonoBehaviour
     {
+#if UNITY_WSA
         /// <summary>
         /// These enums allow us to activate an axis only by a key press, such as CTRL mouse or ALT mouse
         /// </summary>
@@ -168,6 +169,8 @@ namespace HoloToolkit.Unity.InputModule
         }
 #endif
 
+#endif
     }
 
 } // namespace
+

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/ManualGazeControl.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/ManualGazeControl.cs
@@ -11,6 +11,7 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public class ManualGazeControl : MonoBehaviour
     {
+#if UNITY_WSA
         public bool MouseSupported = true;
         public AxisController MouseXYRotationAxisControl;
         public AxisController MouseXYTranslationAxisControl;
@@ -118,6 +119,8 @@ namespace HoloToolkit.Unity.InputModule
             cameraTransform.Rotate(this.lastTrackerToUnityRotation.eulerAngles, Space.World);
             cameraTransform.Translate(this.lastTrackerToUnityTranslation, Space.World);
         }
+#endif
     }
 
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/Utilities/ManualHandControl.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Utilities/ManualHandControl.cs
@@ -85,6 +85,7 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public class ManualHandControl : MonoBehaviour
     {
+#if UNITY_WSA
         public float HandReturnFactor = 0.25f;  /// [0.0,1.0] the closer this is to one the faster it brings the hand back to center
         public float HandTimeBeforeReturn = 0.5f;
         public float MinimumTrackedMovement = 0.001f;
@@ -275,6 +276,7 @@ namespace HoloToolkit.Unity.InputModule
                 RightHandVisualizer.SetActive(VisualizeHands);
             }
         }
+#endif
     }
 
 }

--- a/Assets/HoloToolkit/Input/Scripts/Voice/Editor/KeywordAndKeyCodeDrawer.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Voice/Editor/KeywordAndKeyCodeDrawer.cs
@@ -1,4 +1,7 @@
-﻿using UnityEngine;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
 using UnityEditor;
 
 namespace HoloToolkit.Unity.InputModule
@@ -6,6 +9,7 @@ namespace HoloToolkit.Unity.InputModule
     [CustomPropertyDrawer(typeof(SpeechInputSource.KeywordAndKeyCode))]
     public class KeywordAndKeyCodeDrawer : PropertyDrawer
     {
+#if UNITY_WSA
         public override void OnGUI(Rect rect, SerializedProperty property, GUIContent content)
         {
             EditorGUI.BeginProperty(rect, content, property);
@@ -22,5 +26,7 @@ namespace HoloToolkit.Unity.InputModule
 
             EditorGUI.EndProperty();
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/Voice/Editor/SpeechInputSourceEditor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Voice/Editor/SpeechInputSourceEditor.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using UnityEditor;
 using UnityEngine;
 
@@ -7,6 +10,7 @@ namespace HoloToolkit.Unity.InputModule
     [CustomEditor(typeof(SpeechInputSource))]
     public class SpeechInputSourceEditor : Editor
     {
+#if UNITY_WSA
         public override void OnInspectorGUI()
         {
             SerializedProperty recognizerStart = serializedObject.FindProperty("RecognizerStart");
@@ -72,5 +76,7 @@ namespace HoloToolkit.Unity.InputModule
                 EditorGUI.indentLevel--;
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/Voice/KeywordManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Voice/KeywordManager.cs
@@ -21,6 +21,7 @@ namespace HoloToolkit.Unity.InputModule
     /// </summary>
     public partial class KeywordManager : MonoBehaviour
     {
+#if UNITY_WSA
         [System.Serializable]
         public struct KeywordAndResponse
         {
@@ -162,5 +163,7 @@ namespace HoloToolkit.Unity.InputModule
                 keywordRecognizer.Stop();
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Scripts/Voice/SpeechInputSource.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Voice/SpeechInputSource.cs
@@ -28,6 +28,7 @@ namespace HoloToolkit.Unity.InputModule
             public KeyCode KeyCode;
         }
 
+#if UNITY_WSA
         // This enumeration gives the manager two different ways to handle the recognizer. Both will
         // set up the recognizer and add all keywords. The first causes the recognizer to start
         // immediately. The second allows the recognizer to be manually started at a later time.
@@ -177,5 +178,7 @@ namespace HoloToolkit.Unity.InputModule
         {
             return SupportedInputInfo.None;
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Tests/Scripts/ButtonObjectScaler.cs
+++ b/Assets/HoloToolkit/Input/Tests/Scripts/ButtonObjectScaler.cs
@@ -7,6 +7,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
 {
     public class ButtonObjectScaler : MonoBehaviour
     {
+#if UNITY_WSA
         [SerializeField]
         private TestButton button = null;
 
@@ -69,5 +70,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
 
             button.Selected = false;
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Tests/Scripts/ButtonTimedWaiter.cs
+++ b/Assets/HoloToolkit/Input/Tests/Scripts/ButtonTimedWaiter.cs
@@ -8,6 +8,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
 {
     public class ButtonTimedWaiter : MonoBehaviour
     {
+#if UNITY_WSA
         [SerializeField]
         private TestButton button = null;
 
@@ -50,5 +51,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
 
             yield break;
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Tests/Scripts/DehydrationDeactivation.cs
+++ b/Assets/HoloToolkit/Input/Tests/Scripts/DehydrationDeactivation.cs
@@ -7,6 +7,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
 {
     public class DehydrationDeactivation : StateMachineBehaviour
     {
+#if UNITY_WSA
         /// <summary>
         /// OnStateExit is called when a transition ends and the state machine finishes evaluating this state
         /// </summary>
@@ -17,5 +18,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
         {
             animator.transform.gameObject.SetActive(false);
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Tests/Scripts/DisplayKeywords.cs
+++ b/Assets/HoloToolkit/Input/Tests/Scripts/DisplayKeywords.cs
@@ -8,6 +8,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
 {
     public class DisplayKeywords : MonoBehaviour
     {
+#if UNITY_WSA
         public KeywordManager keywordManager;
         public Text textPanel;
 
@@ -25,5 +26,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
                 textPanel.text += k.Keyword + "\n";
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Tests/Scripts/DisplaySpeechKeywords.cs
+++ b/Assets/HoloToolkit/Input/Tests/Scripts/DisplaySpeechKeywords.cs
@@ -8,6 +8,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
 {
     public class DisplaySpeechKeywords : MonoBehaviour
     {
+#if UNITY_WSA
         public SpeechInputSource speechInputSource;
         public TextMesh textMesh;
 
@@ -25,5 +26,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
                 textMesh.text += " " + item.Keyword + "\n";
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Tests/Scripts/FocusedObjectColorChanger.cs
+++ b/Assets/HoloToolkit/Input/Tests/Scripts/FocusedObjectColorChanger.cs
@@ -1,4 +1,7 @@
-﻿using UnityEngine;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
 
 namespace HoloToolkit.Unity.InputModule.Tests
 {
@@ -8,6 +11,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
     /// </summary>
     public class FocusedObjectColorChanger : MonoBehaviour, IFocusable
     {
+#if UNITY_WSA
         [Tooltip("Object color changes to this when focused.")] public Color FocusedColor = Color.red;
 
         private Material material;
@@ -28,5 +32,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
         {
             material.color = originalColor;
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Tests/Scripts/FocusedObjectMessageSender.cs
+++ b/Assets/HoloToolkit/Input/Tests/Scripts/FocusedObjectMessageSender.cs
@@ -1,4 +1,7 @@
-﻿using UnityEngine;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
 
 namespace HoloToolkit.Unity.InputModule.Tests
 {
@@ -9,6 +12,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
     /// </summary>
     public class FocusedObjectMessageSender : MonoBehaviour
     {
+#if UNITY_WSA
         /// <summary>
         /// Sends message to the object currently focused on by GazeManager.
         /// </summary>
@@ -20,5 +24,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
                 GazeManager.Instance.HitObject.SendMessage(message, SendMessageOptions.DontRequireReceiver);
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Tests/Scripts/InputHandleCallbackFX.cs
+++ b/Assets/HoloToolkit/Input/Tests/Scripts/InputHandleCallbackFX.cs
@@ -7,6 +7,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
 {
     public class InputHandleCallbackFX : MonoBehaviour, IInputClickHandler
     {
+#if UNITY_WSA
         [SerializeField]
         private ParticleSystem particles = null;
 
@@ -20,5 +21,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
             particles.transform.position = GazeManager.Instance.HitPosition;
             particles.Emit(60);
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Tests/Scripts/InputTest.cs
+++ b/Assets/HoloToolkit/Input/Tests/Scripts/InputTest.cs
@@ -18,6 +18,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
                              IManipulationHandler,
                              INavigationHandler
     {
+#if UNITY_WSA
         [Tooltip("Set to true if gestures update (ManipulationUpdated, NavigationUpdated) should be logged. Note that this can impact performance." )]
         public bool LogGesturesUpdateEvents = false;
 
@@ -156,5 +157,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
                 eventData.CumulativeDelta.y,
                 eventData.CumulativeDelta.z);
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Tests/Scripts/MicStreamDemo.cs
+++ b/Assets/HoloToolkit/Input/Tests/Scripts/MicStreamDemo.cs
@@ -17,6 +17,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
     [RequireComponent(typeof(AudioSource))]
     public class MicStreamDemo : MonoBehaviour
     {
+#if UNITY_WSA
         /// <summary>
         /// Which type of microphone/quality to access
         /// </summary>
@@ -159,5 +160,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
             this.OnApplicationPause(false);
         }
 #endif
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Tests/Scripts/OnFocusEvent.cs
+++ b/Assets/HoloToolkit/Input/Tests/Scripts/OnFocusEvent.cs
@@ -1,4 +1,7 @@
-﻿using HoloToolkit.Unity.InputModule;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using HoloToolkit.Unity.InputModule;
 using UnityEngine;
 using UnityEngine.Events;
 
@@ -6,6 +9,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
 {
     public class OnFocusEvent : MonoBehaviour, IFocusable
     {
+#if UNITY_WSA
         public UnityEvent FocusEnterEvent;
         public UnityEvent FocusLostEvent;
 
@@ -31,5 +35,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
                 FocusLostEvent.Invoke();
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Tests/Scripts/PopupMenu.cs
+++ b/Assets/HoloToolkit/Input/Tests/Scripts/PopupMenu.cs
@@ -8,6 +8,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
 {
     public class PopupMenu : MonoBehaviour, IInputClickHandler
     {
+#if UNITY_WSA
         [SerializeField]
         private TestButton cancelButton = null;
 
@@ -142,5 +143,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
                 Dismiss();
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Tests/Scripts/ScaleObjectMessageReceiver.cs
+++ b/Assets/HoloToolkit/Input/Tests/Scripts/ScaleObjectMessageReceiver.cs
@@ -1,9 +1,13 @@
-﻿using UnityEngine;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
 
 namespace HoloToolkit.Unity.InputModule.Tests
 {
     public class ScaleObjectMessageReceiver : MonoBehaviour
     {
+#if UNITY_WSA
         private const float DefaultSizeFactor = 2.0f;
 
         [Tooltip("Size multiplier to use when scaling the object up and down.")]
@@ -30,5 +34,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
             scale /= SizeFactor;
             transform.localScale = scale;
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Tests/Scripts/SelectedObjectMessageReceiver.cs
+++ b/Assets/HoloToolkit/Input/Tests/Scripts/SelectedObjectMessageReceiver.cs
@@ -1,4 +1,7 @@
-﻿using UnityEngine;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
 
 namespace HoloToolkit.Unity.InputModule.Tests
 {
@@ -8,6 +11,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
     /// </summary>
     public class SelectedObjectMessageReceiver : MonoBehaviour
     {
+#if UNITY_WSA
         [Tooltip("Object color changes to this when selected.")] public Color SelectedColor = Color.red;
 
         private Material material;
@@ -28,5 +32,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
         {
             material.color = originalColor;
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Tests/Scripts/SelectedObjectMessageSender.cs
+++ b/Assets/HoloToolkit/Input/Tests/Scripts/SelectedObjectMessageSender.cs
@@ -1,4 +1,7 @@
-﻿using UnityEngine;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
 
 namespace HoloToolkit.Unity.InputModule.Tests
 {
@@ -10,6 +13,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
     /// </summary>
     public class SelectedObjectMessageSender : MonoBehaviour
     {
+#if UNITY_WSA
         /// <summary>
         /// Currently selected object.
         /// </summary>
@@ -45,5 +49,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
                 selectedObject.SendMessage(message, SendMessageOptions.DontRequireReceiver);
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Tests/Scripts/SimpleGridGenerator.cs
+++ b/Assets/HoloToolkit/Input/Tests/Scripts/SimpleGridGenerator.cs
@@ -1,10 +1,14 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace HoloToolkit.Unity.InputModule.Tests
 {
     public class SimpleGridGenerator : MonoBehaviour
     {
+#if UNITY_WSA
         private const int DefaultRows = 3;
         private const int DefaultColumns = 3;
 
@@ -56,5 +60,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
             }
             return null;
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Tests/Scripts/SphereGlobalKeywords.cs
+++ b/Assets/HoloToolkit/Input/Tests/Scripts/SphereGlobalKeywords.cs
@@ -8,6 +8,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
 {
     public class SphereGlobalKeywords : MonoBehaviour, ISpeechHandler
     {
+#if UNITY_WSA
         public void OnSpeechKeywordRecognized(SpeechKeywordRecognizedEventData eventData)
         {
             switch (eventData.RecognizedText.ToLower())
@@ -20,5 +21,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
                     break;
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Tests/Scripts/SphereKeywords.cs
+++ b/Assets/HoloToolkit/Input/Tests/Scripts/SphereKeywords.cs
@@ -8,6 +8,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
 {
     public class SphereKeywords : MonoBehaviour, ISpeechHandler
     {
+#if UNITY_WSA
         public void ChangeColor(string color)
         {
             switch (color.ToLower())
@@ -28,5 +29,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
         {
             ChangeColor(eventData.RecognizedText);
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Tests/Scripts/TestButton.cs
+++ b/Assets/HoloToolkit/Input/Tests/Scripts/TestButton.cs
@@ -12,6 +12,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
     /// </summary>
     public class TestButton : MonoBehaviour, IInputClickHandler, IFocusable
     {
+#if UNITY_WSA
         public Transform ToolTip;
         public Renderer ToolTipRenderer;
 
@@ -229,5 +230,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
 
             UpdateVisuals();
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Input/Tests/Scripts/TogglePopupMenu.cs
+++ b/Assets/HoloToolkit/Input/Tests/Scripts/TogglePopupMenu.cs
@@ -8,6 +8,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
 {
     public class TogglePopupMenu : MonoBehaviour
     {
+#if UNITY_WSA
 
         [SerializeField]
         private PopupMenu popupMenu = null;
@@ -59,5 +60,7 @@ namespace HoloToolkit.Unity.InputModule.Tests
                 button.Selected = false;
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Sharing/Editor/SharingMenu.cs
+++ b/Assets/HoloToolkit/Sharing/Editor/SharingMenu.cs
@@ -9,6 +9,7 @@ namespace HoloToolkit.Sharing
 {
     public static class SharingMenu
     {
+#if UNITY_WSA
         [MenuItem("HoloToolkit/Sharing Service/Launch Sharing Service", false, 100)]
         public static void LaunchSessionServer()
         {
@@ -53,5 +54,7 @@ namespace HoloToolkit.Sharing
 
             Utilities.ExternalProcess.FindAndLaunch(filePathName);
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Sharing/Scripts/SDK/DiscoveryClientAdapter.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/SDK/DiscoveryClientAdapter.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -7,6 +10,7 @@ namespace HoloToolkit.Sharing
 {
     public class DiscoveryClientAdapter : DiscoveryClientListener
     {
+#if UNITY_WSA
         public event Action<DiscoveredSystem> DiscoveredEvent;
         public event Action<DiscoveredSystem> LostEvent;
 
@@ -25,5 +29,7 @@ namespace HoloToolkit.Sharing
                 this.LostEvent(remoteSystem);
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Sharing/Scripts/SDK/ObjectElementAdapter.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/SDK/ObjectElementAdapter.cs
@@ -1,6 +1,5 @@
-﻿//
-// Copyright (C) Microsoft. All rights reserved.
-//
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 namespace HoloToolkit.Sharing
 {
@@ -10,6 +9,7 @@ namespace HoloToolkit.Sharing
     /// </summary>
     public class ObjectElementAdapter : ObjectElementListener
     {
+#if UNITY_WSA
         public event System.Action<long, int> IntChangedEvent;
         public event System.Action<long, double> DoubleChangedEvent;
         public event System.Action<long, float> FloatChangedEvent;
@@ -141,5 +141,7 @@ namespace HoloToolkit.Sharing
             }
             Profile.EndRange();
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Sharing/Scripts/SDK/PairingAdapter.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/SDK/PairingAdapter.cs
@@ -1,4 +1,5 @@
-﻿
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 namespace HoloToolkit.Sharing
 {
@@ -8,6 +9,7 @@ namespace HoloToolkit.Sharing
     /// </summary>
     public class PairingAdapter : PairingListener
     {
+#if UNITY_WSA
         public event System.Action SuccessEvent;
         public event System.Action<PairingResult> FailureEvent;
 
@@ -28,5 +30,7 @@ namespace HoloToolkit.Sharing
                 this.FailureEvent(result);
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Sharing/Scripts/SDK/SessionManagerAdapter.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/SDK/SessionManagerAdapter.cs
@@ -1,6 +1,5 @@
-//
-// Copyright (C) Microsoft. All rights reserved.
-//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 namespace HoloToolkit.Sharing
 {
@@ -10,6 +9,7 @@ namespace HoloToolkit.Sharing
     /// </summary>
     public class SessionManagerAdapter : SessionManagerListener
     {
+#if UNITY_WSA
         public event System.Action<Session> CreateSucceededEvent;
         public event System.Action<XString> CreateFailedEvent;
         public event System.Action<Session> SessionAddedEvent;
@@ -111,5 +111,7 @@ namespace HoloToolkit.Sharing
             }
             Profile.EndRange();
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Sharing/Scripts/SDK/UserPresenceManagerAdapter.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/SDK/UserPresenceManagerAdapter.cs
@@ -1,6 +1,5 @@
-﻿//
-// Copyright (C) Microsoft. All rights reserved.
-//
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 namespace HoloToolkit.Sharing
 {
@@ -10,6 +9,7 @@ namespace HoloToolkit.Sharing
     /// </summary>
     public class UserPresenceManagerAdapter : UserPresenceManagerListener
     {
+#if UNITY_WSA
         public event System.Action<User> UserPresenceChangedEvent;
 
         public UserPresenceManagerAdapter() { }
@@ -21,5 +21,7 @@ namespace HoloToolkit.Sharing
                 this.UserPresenceChangedEvent(user);
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Sharing/Scripts/SharingSessionTracker.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/SharingSessionTracker.cs
@@ -1,4 +1,7 @@
-﻿using HoloToolkit.Unity;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using HoloToolkit.Unity;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -10,6 +13,7 @@ namespace HoloToolkit.Sharing
     /// </summary>
     public class SharingSessionTracker : Singleton<SharingSessionTracker>
     {
+#if UNITY_WSA
         public class SessionJoinedEventArgs : EventArgs
         {
             public User joiningUser;
@@ -172,5 +176,7 @@ namespace HoloToolkit.Sharing
                 }
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Sharing/Scripts/SharingStage.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/SharingStage.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using HoloToolkit.Unity;
 using UnityEngine;
 
@@ -6,6 +9,7 @@ namespace HoloToolkit.Sharing
 {
     public class SharingStage : Singleton<SharingStage>
     {
+#if UNITY_WSA
         /// <summary>
         /// SharingManagerConnected event notifies when the sharing manager is created and connected.
         /// </summary>
@@ -245,5 +249,7 @@ namespace HoloToolkit.Sharing
                     break;
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Sharing/Scripts/Utilities/AutoJoinSession.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/Utilities/AutoJoinSession.cs
@@ -7,6 +7,7 @@ namespace HoloToolkit.Sharing
 {
     public class AutoJoinSession : MonoBehaviour
     {
+#if UNITY_WSA
         // The name of the session to join
         public string SessionName = "Default";
 
@@ -77,5 +78,7 @@ namespace HoloToolkit.Sharing
                 }
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Sharing/Scripts/Utilities/ConsoleLogWriter.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/Utilities/ConsoleLogWriter.cs
@@ -7,6 +7,7 @@ namespace HoloToolkit.Sharing
 {
     public class ConsoleLogWriter : LogWriter
     {
+#if UNITY_WSA
         public override void WriteLogEntry(LogSeverity severity, string message)
         {
             if (severity == LogSeverity.Info)
@@ -22,5 +23,7 @@ namespace HoloToolkit.Sharing
                 Debug.LogError(message);
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Sharing/Scripts/Utilities/DirectPairing.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/Utilities/DirectPairing.cs
@@ -1,4 +1,7 @@
-﻿using UnityEngine;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
 
 namespace HoloToolkit.Sharing
 {
@@ -9,6 +12,7 @@ namespace HoloToolkit.Sharing
     /// </summary>
     public class DirectPairing : MonoBehaviour
     {
+#if UNITY_WSA
         public enum Role
         {
             Connector,
@@ -119,5 +123,7 @@ namespace HoloToolkit.Sharing
                 }
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Sharing/Scripts/Utilities/ExternalProcess.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/Utilities/ExternalProcess.cs
@@ -11,6 +11,7 @@ using UnityEngine;
 
 namespace HoloToolkit.Sharing.Utilities
 {
+#if UNITY_WSA
     public class ExternalProcess : IDisposable
     {
         [DllImport("ExternalProcessAPI", CallingConvention = CallingConvention.Cdecl)]
@@ -286,5 +287,7 @@ namespace HoloToolkit.Sharing.Utilities
             this.Terminate();
         }
     }
+#endif
 }
 #endif
+

--- a/Assets/HoloToolkit/Sharing/Scripts/Utilities/MathUtils.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/Utilities/MathUtils.cs
@@ -1,6 +1,5 @@
-﻿//
-// Copyright (C) Microsoft. All rights reserved.
-//
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Collections.Generic;
 using System.Linq;
@@ -10,6 +9,7 @@ namespace HoloToolkit.Sharing.Utilities
 {
     public static class MathUtils
     {
+#if UNITY_WSA
         /// <summary>
         /// Get the horizontal FOV from the stereo camera
         /// </summary>
@@ -447,5 +447,7 @@ namespace HoloToolkit.Sharing.Utilities
             Vector3 nearestPoint = sumOfProductInverse * sumOfProductTimesDirection;
             return nearestPoint;
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Sharing/Scripts/Utilities/Utils.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/Utilities/Utils.cs
@@ -1,6 +1,5 @@
-﻿//
-// Copyright (C) Microsoft. All rights reserved.
-//
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using UnityEngine;
 
@@ -8,6 +7,7 @@ namespace HoloToolkit.Sharing.Utilities
 {
     public static class Utils
     {
+#if UNITY_WSA
         public static void SetLayerRecursively(GameObject gameObject, int layer)
         {
             gameObject.layer = layer;
@@ -167,5 +167,7 @@ namespace HoloToolkit.Sharing.Utilities
             }
             return null;
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Sharing/Tests/CustomMessages.cs
+++ b/Assets/HoloToolkit/Sharing/Tests/CustomMessages.cs
@@ -9,6 +9,7 @@ using UnityEngine;
 
 public class CustomMessages : Singleton<CustomMessages>
 {
+#if UNITY_WSA
     /// <summary>
     /// Message enum containing our information bytes to share.
     /// The first message type has to start with UserMessageIDStart
@@ -188,4 +189,6 @@ public class CustomMessages : Singleton<CustomMessages>
     }
 
     #endregion HelperFunctionsForReading
+#endif
 }
+

--- a/Assets/HoloToolkit/Sharing/Tests/ImportExportAnchorManager.cs
+++ b/Assets/HoloToolkit/Sharing/Tests/ImportExportAnchorManager.cs
@@ -15,6 +15,7 @@ using UnityEngine.VR.WSA.Sharing;
 /// </summary>
 public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
 {
+#if UNITY_WSA
     /// <summary>
     /// Enum to track the progress through establishing a shared coordinate system.
     /// </summary>
@@ -537,4 +538,6 @@ public class ImportExportAnchorManager : Singleton<ImportExportAnchorManager>
             currentState = ImportExportState.InitialAnchorRequired;
         }
     }
+#endif
 }
+

--- a/Assets/HoloToolkit/Sharing/Tests/RemoteHeadManager.cs
+++ b/Assets/HoloToolkit/Sharing/Tests/RemoteHeadManager.cs
@@ -14,6 +14,7 @@ using UnityEngine;
 /// </summary>
 public class RemoteHeadManager : Singleton<RemoteHeadManager>
 {
+#if UNITY_WSA
     public class RemoteHeadInfo
     {
         public long UserID;
@@ -133,4 +134,6 @@ public class RemoteHeadManager : Singleton<RemoteHeadManager>
     {
         DestroyImmediate(remoteHeadObject);
     }
+#endif
 }
+

--- a/Assets/HoloToolkit/SpatialMapping/Scripts/ObjectSurfaceObserver.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/ObjectSurfaceObserver.cs
@@ -8,6 +8,7 @@ namespace HoloToolkit.Unity.SpatialMapping
 {
     public class ObjectSurfaceObserver : SpatialMappingSource
     {
+#if UNITY_WSA
         [Tooltip("The room model to use when loading meshes in Unity.")]
         public GameObject RoomModel;
 
@@ -80,5 +81,7 @@ namespace HoloToolkit.Unity.SpatialMapping
                 }
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialMapping/Scripts/RemoteMapping/FileSurfaceObserver.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/RemoteMapping/FileSurfaceObserver.cs
@@ -8,6 +8,7 @@ namespace HoloToolkit.Unity.SpatialMapping
 {
     public class FileSurfaceObserver : SpatialMappingSource
     {
+#if UNITY_WSA
         [Tooltip("The file name to use when saving and loading meshes.")]
         public string MeshFileName = "roombackup";
 
@@ -85,5 +86,7 @@ namespace HoloToolkit.Unity.SpatialMapping
             }
 #endif
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialMapping/Scripts/RemoteMapping/MeshSaver.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/RemoteMapping/MeshSaver.cs
@@ -18,6 +18,7 @@ namespace HoloToolkit.Unity.SpatialMapping
     /// </summary>
     public static class MeshSaver
     {
+#if UNITY_WSA
         /// <summary>
         /// The extension given to mesh files.
         /// </summary>
@@ -159,5 +160,7 @@ namespace HoloToolkit.Unity.SpatialMapping
 #endif
             return stream;
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialMapping/Scripts/RemoteMapping/RemoteMappingManager.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/RemoteMapping/RemoteMappingManager.cs
@@ -11,6 +11,7 @@ namespace HoloToolkit.Unity.SpatialMapping
     [RequireComponent(typeof(RemoteMeshTarget))]
     public partial class RemoteMappingManager : Singleton<RemoteMappingManager>
     {
+#if UNITY_WSA
         [Tooltip("Key to press in editor to enable spatial mapping over the network.")]
         public KeyCode RemoteMappingKey = KeyCode.N;
 
@@ -112,5 +113,7 @@ namespace HoloToolkit.Unity.SpatialMapping
             }
 #endif
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialMapping/Scripts/RemoteMapping/RemoteMeshSource.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/RemoteMapping/RemoteMeshSource.cs
@@ -3,7 +3,7 @@
 
 using UnityEngine;
 
-#if !UNITY_EDITOR && UNITY_METRO
+#if !UNITY_EDITOR && UNITY_WSA
 using System.Collections.Generic;
 using Windows.Networking.Sockets;
 using Windows.Storage.Streams;
@@ -24,7 +24,7 @@ namespace HoloToolkit.Unity.SpatialMapping
         [Tooltip("The connection port on the machine to use.")]
         public int ConnectionPort = 11000;
 
-#if !UNITY_EDITOR && UNITY_METRO
+#if !UNITY_EDITOR && UNITY_WSA
         /// <summary>
         /// Tracks the network connection to the remote machine we are sending meshes to.
         /// </summary>

--- a/Assets/HoloToolkit/SpatialMapping/Scripts/RemoteMapping/RemoteMeshTarget.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/RemoteMapping/RemoteMeshTarget.cs
@@ -20,7 +20,8 @@ namespace HoloToolkit.Unity.SpatialMapping
     /// </summary>
     public class RemoteMeshTarget : SpatialMappingSource
     {
-        [Tooltip("The IPv4 Address of the machine running the Unity editor.")]
+#if UNITY_WSA
+		[Tooltip("The IPv4 Address of the machine running the Unity editor.")]
         public string ServerIP;
 
         [Tooltip("The connection port on the machine to use.")]
@@ -157,5 +158,7 @@ namespace HoloToolkit.Unity.SpatialMapping
             }
         }
 #endif
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialMapping/Scripts/RemoteMapping/SimpleMeshSerializer.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/RemoteMapping/SimpleMeshSerializer.cs
@@ -218,3 +218,4 @@ namespace HoloToolkit.Unity.SpatialMapping
         }
     }
 }
+

--- a/Assets/HoloToolkit/SpatialMapping/Scripts/SpatialMappingManager.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/SpatialMappingManager.cs
@@ -15,6 +15,7 @@ namespace HoloToolkit.Unity.SpatialMapping
     [RequireComponent(typeof(SpatialMappingObserver))]
     public partial class SpatialMappingManager : Singleton<SpatialMappingManager>
     {
+#if UNITY_WSA
         [Tooltip("The physics layer for spatial mapping objects to be set to.")]
         public int PhysicsLayer = 31;
 
@@ -301,5 +302,7 @@ namespace HoloToolkit.Unity.SpatialMapping
                 }
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialMapping/Scripts/SpatialMappingObserver.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/SpatialMappingObserver.cs
@@ -29,6 +29,7 @@ namespace HoloToolkit.Unity.SpatialMapping
     /// </summary>
     public class SpatialMappingObserver : SpatialMappingSource
     {
+#if UNITY_WSA
         [Tooltip("The number of triangles to calculate per cubic meter.")]
         public float TrianglesPerCubicMeter = 500f;
 
@@ -389,5 +390,7 @@ namespace HoloToolkit.Unity.SpatialMapping
             StopObserving();
             CleanupObserver();
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialMapping/Scripts/SpatialMappingSource.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/SpatialMappingSource.cs
@@ -9,6 +9,7 @@ namespace HoloToolkit.Unity.SpatialMapping
 {
     public class SpatialMappingSource : MonoBehaviour
     {
+#if UNITY_WSA
         /// <summary>
         /// Surface object
         /// </summary>
@@ -182,5 +183,7 @@ namespace HoloToolkit.Unity.SpatialMapping
 
             return meshRenderers;
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialMapping/Scripts/SpatialProcessing/PlaneFinding.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/SpatialProcessing/PlaneFinding.cs
@@ -69,6 +69,7 @@ namespace HoloToolkit.Unity.SpatialMapping
             }
         }
 
+#if UNITY_WSA
         /// <summary>
         /// Finds small planar patches that are contained within individual meshes.  The output of this
         /// API can then be passed to MergeSubPlanes() in order to find larger planar surfaces that
@@ -175,10 +176,10 @@ namespace HoloToolkit.Unity.SpatialMapping
                 FinishPlaneFinding();
             }
         }
-
-        #endregion
-
-        #region Internal
+#endif
+		#endregion
+#if UNITY_WSA
+		#region Internal
 
         private static bool findPlanesRunning = false;
         private static System.Object findPlanesLock = new System.Object();
@@ -334,6 +335,8 @@ namespace HoloToolkit.Unity.SpatialMapping
                 [Out] out IntPtr planesPtr);
         }
 
-        #endregion
-    }
+		#endregion
+#endif
+	}
 }
+

--- a/Assets/HoloToolkit/SpatialMapping/Scripts/SpatialProcessing/RemoveSurfaceVertices.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/SpatialProcessing/RemoveSurfaceVertices.cs
@@ -14,6 +14,7 @@ namespace HoloToolkit.Unity.SpatialMapping
     /// </summary>
     public class RemoveSurfaceVertices : Singleton<RemoveSurfaceVertices>
     {
+#if UNITY_WSA
         [Tooltip("The amount, if any, to expand each bounding volume by.")]
         public float BoundsExpansion = 0.0f;
 
@@ -239,5 +240,7 @@ namespace HoloToolkit.Unity.SpatialMapping
 
             removingVerts = false;
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialMapping/Scripts/SpatialProcessing/SurfaceMeshesToPlanes.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/SpatialProcessing/SurfaceMeshesToPlanes.cs
@@ -6,7 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-#if !UNITY_EDITOR && UNITY_METRO
+#if !UNITY_EDITOR && UNITY_WSA
 using System.Threading;
 using System.Threading.Tasks;
 #endif
@@ -22,7 +22,8 @@ namespace HoloToolkit.Unity.SpatialMapping
     /// </summary>
     public class SurfaceMeshesToPlanes : Singleton<SurfaceMeshesToPlanes>
     {
-        [Tooltip("Currently active planes found within the Spatial Mapping Mesh.")]
+#if UNITY_WSA
+		[Tooltip("Currently active planes found within the Spatial Mapping Mesh.")]
         public List<GameObject> ActivePlanes;
 
         [Tooltip("Object used for creating and rendering Surface Planes.")]
@@ -308,6 +309,7 @@ namespace HoloToolkit.Unity.SpatialMapping
         {
             surfacePlane.IsVisible = ((drawPlanesMask & surfacePlane.PlaneType) == surfacePlane.PlaneType);
         }
+#endif
     }
 
 #if UNITY_EDITOR
@@ -342,3 +344,4 @@ namespace HoloToolkit.Unity.SpatialMapping
     }
 #endif
 }
+

--- a/Assets/HoloToolkit/SpatialMapping/Scripts/SpatialProcessing/SurfacePlane.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/SpatialProcessing/SurfacePlane.cs
@@ -59,6 +59,7 @@ namespace HoloToolkit.Unity.SpatialMapping
 
         [Tooltip("Type of plane that the object has been classified as.")]
         public PlaneTypes PlaneType = PlaneTypes.Unknown;
+#if UNITY_WSA
 
         /// <summary>
         /// The BoundedPlane associated with the SurfacePlane object.
@@ -224,5 +225,7 @@ namespace HoloToolkit.Unity.SpatialMapping
                     break;
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialMapping/Scripts/TapToPlace.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/TapToPlace.cs
@@ -20,6 +20,7 @@ namespace HoloToolkit.Unity.SpatialMapping
 
     public class TapToPlace : MonoBehaviour, IInputClickHandler
     {
+#if UNITY_WSA
         [Tooltip("Supply a friendly name for the anchor as the key name for the WorldAnchorStore.")]
         public string SavedAnchorFriendlyName = "SavedAnchorFriendlyName";
 
@@ -161,5 +162,7 @@ namespace HoloToolkit.Unity.SpatialMapping
                 }
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialMapping/Tests/Scripts/PlaneFindingTest.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Tests/Scripts/PlaneFindingTest.cs
@@ -13,6 +13,7 @@ namespace HoloToolkit.Unity.SpatialMapping.Tests
     /// </summary>
     public class PlaneFindingTest : MonoBehaviour
     {
+#if UNITY_WSA
         [Range(0, 45)]
         public float SnapToGravityThreshold = 0.0f;
 
@@ -137,5 +138,7 @@ namespace HoloToolkit.Unity.SpatialMapping.Tests
             }
         }
 #endif
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialMapping/Tests/Scripts/SpatialProcessingTest.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Tests/Scripts/SpatialProcessingTest.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace HoloToolkit.Unity.SpatialMapping.Tests
@@ -9,6 +12,7 @@ namespace HoloToolkit.Unity.SpatialMapping.Tests
     /// </summary>
     public class SpatialProcessingTest : Singleton<SpatialProcessingTest>
     {
+#if UNITY_WSA
         [Tooltip("How much time (in seconds) that the SurfaceObserver will run after being started; used when 'Limit Scanning By Time' is checked.")]
         public float scanTime = 30.0f;
 
@@ -142,5 +146,7 @@ namespace HoloToolkit.Unity.SpatialMapping.Tests
 
             base.OnDestroy();
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialSound/Scripts/AudioEmitter.cs
+++ b/Assets/HoloToolkit/SpatialSound/Scripts/AudioEmitter.cs
@@ -13,6 +13,7 @@ namespace HoloToolkit.Unity
     [RequireComponent(typeof(AudioSource))]    
     public class AudioEmitter : MonoBehaviour 
     {
+#if UNITY_WSA
         [Tooltip("Time, in seconds, between audio influence updates.  0 indicates to update every frame.")]
         [Range(0.0f, 1.0f)]
         public float UpdateInterval = 0.25f;
@@ -135,5 +136,7 @@ namespace HoloToolkit.Unity
 
             return influencers;
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialSound/Scripts/AudioOccluder.cs
+++ b/Assets/HoloToolkit/SpatialSound/Scripts/AudioOccluder.cs
@@ -11,6 +11,7 @@ namespace HoloToolkit.Unity
     /// </summary>
     public class AudioOccluder : MonoBehaviour, IAudioInfluencer
     {
+#if UNITY_WSA
         /// <summary>
         /// Frequency above the nominal range of human hearing. Applying this frequency to the filter will have no perceived impact on the audio source.
         /// </summary>
@@ -79,5 +80,7 @@ namespace HoloToolkit.Unity
 
             // Note: Volume attenuation is reset in the emitter.
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialSound/Scripts/IAudioInfluencer.cs
+++ b/Assets/HoloToolkit/SpatialSound/Scripts/IAudioInfluencer.cs
@@ -10,6 +10,7 @@ namespace HoloToolkit.Unity
     /// </summary>
     public interface IAudioInfluencer
     {
+#if UNITY_WSA
         /// <summary>
         /// Applies an audio effect.
         /// </summary>
@@ -25,5 +26,7 @@ namespace HoloToolkit.Unity
         /// <param name="audioSource">The AudioSource that will be impacted by the effect.</param>
         void RemoveEffect(GameObject emitter,
                         AudioSource audioSource);
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialSound/Scripts/UAudioManager/ActiveEvent.cs
+++ b/Assets/HoloToolkit/SpatialSound/Scripts/UAudioManager/ActiveEvent.cs
@@ -11,6 +11,7 @@ namespace HoloToolkit.Unity
     /// </summary>
     public class ActiveEvent : IDisposable
     {
+#if UNITY_WSA
         private AudioSource primarySource = null;
         public AudioSource PrimarySource
         {
@@ -232,10 +233,11 @@ namespace HoloToolkit.Unity
 
             this.PrimarySource.pitch = newPitch;
         }
-
+#endif
         public void Dispose()
         {
-            if (this.primarySource != null)
+#if UNITY_WSA
+			if (this.primarySource != null)
             {
                 this.primarySource.enabled = false;
                 this.primarySource = null;
@@ -246,12 +248,13 @@ namespace HoloToolkit.Unity
                 this.secondarySource.enabled = false;
                 this.secondarySource = null;
             }
+#endif
         }
-
-        /// <summary>
-        /// Creates a flat animation curve to negate Unity's distance attenuation when using Spatial Sound
-        /// </summary>
-        public static void CreateFlatSpatialRolloffCurve()
+#if UNITY_WSA
+		/// <summary>
+		/// Creates a flat animation curve to negate Unity's distance attenuation when using Spatial Sound
+		/// </summary>
+		public static void CreateFlatSpatialRolloffCurve()
         {
             if (SpatialRolloff != null)
             {
@@ -261,5 +264,7 @@ namespace HoloToolkit.Unity
             SpatialRolloff.AddKey(0, 1);
             SpatialRolloff.AddKey(1, 1);
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialSound/Scripts/UAudioManager/AudioClip.cs
+++ b/Assets/HoloToolkit/SpatialSound/Scripts/UAudioManager/AudioClip.cs
@@ -11,10 +11,13 @@ namespace HoloToolkit.Unity
     [Serializable]
     public class UAudioClip
     {
+#if UNITY_WSA
         public UnityEngine.AudioClip sound = null;
         public bool looping = false;
 
         public float delayCenter = 0;
         public float delayRandomization = 0;
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialSound/Scripts/UAudioManager/AudioContainer.cs
+++ b/Assets/HoloToolkit/SpatialSound/Scripts/UAudioManager/AudioContainer.cs
@@ -13,6 +13,7 @@ namespace HoloToolkit.Unity
     [Serializable]
     public class AudioContainer
     {
+#if UNITY_WSA
         [Tooltip("The type of the audio container.")]
         public AudioContainerType containerType = AudioContainerType.Random;
 
@@ -21,5 +22,7 @@ namespace HoloToolkit.Unity
         public UAudioClip[] sounds = null;
         public float crossfadeTime = 0f;
         public int currentClip = 0;
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialSound/Scripts/UAudioManager/AudioEvent.cs
+++ b/Assets/HoloToolkit/SpatialSound/Scripts/UAudioManager/AudioEvent.cs
@@ -46,6 +46,7 @@ namespace HoloToolkit.Unity
         [Tooltip("The name of this AudioEvent.")]
         public string name = "_NewAudioEvent";
 
+#if UNITY_WSA
         [Tooltip("How this sound is to be positioned.")]
         public SpatialPositioningType spatialization = SpatialPositioningType.TwoD;
 
@@ -159,6 +160,7 @@ namespace HoloToolkit.Unity
         /// <returns>An integer that indicates whether this AudioEvent precedes (-1), follows (1),
         /// or appears in the same position (0) in the sort order as the AudioEvent being compared.</returns>
         /// <remarks>If the specified object is not an AudioEvent, the return value is 1.</remarks>
+#endif
         public int CompareTo(object obj)
         {
             if (obj == null) return 1;
@@ -185,5 +187,6 @@ namespace HoloToolkit.Unity
             if (other == null) return 1;
             return string.Compare(name, other.name);
         }
-    }
+	}
 }
+

--- a/Assets/HoloToolkit/SpatialSound/Scripts/UAudioManager/AudioSourcePlayClipExtension.cs
+++ b/Assets/HoloToolkit/SpatialSound/Scripts/UAudioManager/AudioSourcePlayClipExtension.cs
@@ -10,11 +10,14 @@ namespace HoloToolkit.Unity
     /// </summary>
     public static class AudioSourcePlayClipExtension
     {
+#if UNITY_WSA
         public static void PlayClip(this AudioSource source, UnityEngine.AudioClip clip, bool loop = false)
         {
             source.clip = clip;
             source.loop = loop;
             source.Play();
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialSound/Scripts/UAudioManager/AudioSourcesReference.cs
+++ b/Assets/HoloToolkit/SpatialSound/Scripts/UAudioManager/AudioSourcesReference.cs
@@ -13,6 +13,7 @@ namespace HoloToolkit.Unity
     /// </summary>
     public class AudioSourcesReference : MonoBehaviour
     {
+#if UNITY_WSA
         private List<AudioSource> audioSources;
         public List<AudioSource> AudioSources
         {
@@ -51,5 +52,7 @@ namespace HoloToolkit.Unity
 
             audioSources = null;
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialSound/Scripts/UAudioManager/Editor/UAudioManagerBaseEditor.cs
+++ b/Assets/HoloToolkit/SpatialSound/Scripts/UAudioManager/Editor/UAudioManagerBaseEditor.cs
@@ -9,6 +9,7 @@ namespace HoloToolkit.Unity
 {
     public class UAudioManagerBaseEditor<TEvent> : Editor where TEvent : AudioEvent, new()
     {
+#if UNITY_WSA
         protected UAudioManagerBase<TEvent> myTarget;
         private string[] eventNames;
         private int selectedEventIndex = 0;
@@ -352,5 +353,7 @@ namespace HoloToolkit.Unity
 
             return newArray;
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialSound/Scripts/UAudioManager/Editor/UAudioManagerEditor.cs
+++ b/Assets/HoloToolkit/SpatialSound/Scripts/UAudioManager/Editor/UAudioManagerEditor.cs
@@ -8,6 +8,7 @@ namespace HoloToolkit.Unity
     [CustomEditor(typeof(UAudioManager))]
     public class UAudioManagerEditor : UAudioManagerBaseEditor<AudioEvent>
     {
+#if UNITY_WSA
         private void OnEnable()
         {
             this.myTarget = (UAudioManager)target;
@@ -20,5 +21,7 @@ namespace HoloToolkit.Unity
             EditorGUILayout.PropertyField(this.serializedObject.FindProperty("globalInstanceBehavior"));
             DrawInspectorGUI(false);
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialSound/Scripts/UAudioManager/Editor/UAudioMiniManagerEditor.cs
+++ b/Assets/HoloToolkit/SpatialSound/Scripts/UAudioManager/Editor/UAudioMiniManagerEditor.cs
@@ -8,6 +8,7 @@ namespace HoloToolkit.Unity
     [CustomEditor(typeof(UAudioMiniManager))]
     public class UAudioMiniManagerEditor : UAudioManagerBaseEditor<MiniAudioEvent>
     {
+#if UNITY_WSA
         private void OnEnable()
         {
             this.myTarget = (UAudioMiniManager)target;
@@ -18,5 +19,7 @@ namespace HoloToolkit.Unity
         {
             DrawInspectorGUI(true);
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialSound/Scripts/UAudioManager/Editor/UAudioProfiler.cs
+++ b/Assets/HoloToolkit/SpatialSound/Scripts/UAudioManager/Editor/UAudioProfiler.cs
@@ -9,6 +9,7 @@ namespace HoloToolkit.Unity
 {
     public class UAudioProfiler : EditorWindow
     {
+#if UNITY_WSA
         private int currentFrame = 0;
         private List<ProfilerEvent[]> eventTimeline;
         private Vector2 scrollOffset = new Vector2();
@@ -117,5 +118,7 @@ namespace HoloToolkit.Unity
         {
             EditorGUILayout.SelectableLabel(currentEvent.EventName + "-->(" + currentEvent.EmitterName + ")-->(" + currentEvent.BusName + ")");
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialSound/Scripts/UAudioManager/MiniAudioEvent.cs
+++ b/Assets/HoloToolkit/SpatialSound/Scripts/UAudioManager/MiniAudioEvent.cs
@@ -12,10 +12,13 @@ namespace HoloToolkit.Unity
     [Serializable]
     public class MiniAudioEvent : AudioEvent
     {
+#if UNITY_WSA
         [Tooltip("The primary AudioSource.")]
         public AudioSource primarySource = null;
 
         [Tooltip("The secondary AudioSource for continuous containers.")]
         public AudioSource secondarySource = null;
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialSound/Scripts/UAudioManager/SpatialSoundSettings.cs
+++ b/Assets/HoloToolkit/SpatialSound/Scripts/UAudioManager/SpatialSoundSettings.cs
@@ -22,6 +22,7 @@ namespace HoloToolkit.Unity
     /// </summary>
     public static class SpatialSoundSettings
     {
+#if UNITY_WSA
         public const SpatialSoundRoomSizes DefaultSpatialSoundRoom = SpatialSoundRoomSizes.Small;
 
         // Ranges and default values for the Microsoft Spatial Sound Spatializer parameters.
@@ -96,5 +97,7 @@ namespace HoloToolkit.Unity
         {
             audioSource.SetSpatializerFloat((int)param, value);
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialSound/Scripts/UAudioManager/UAudioManager.cs
+++ b/Assets/HoloToolkit/SpatialSound/Scripts/UAudioManager/UAudioManager.cs
@@ -14,6 +14,7 @@ namespace HoloToolkit.Unity
     /// </summary>
     public partial class UAudioManager : UAudioManagerBase<AudioEvent>
     {
+#if UNITY_WSA
         [Tooltip("The maximum number of AudioEvents that can be played at once. Zero (0) indicates there is no limit.")]
         [SerializeField]
         private int globalEventInstanceLimit = 0;
@@ -476,5 +477,7 @@ namespace HoloToolkit.Unity
             Array.Sort<AudioEvent>(events);
         }
 #endif
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialSound/Scripts/UAudioManager/UAudioManagerBase.cs
+++ b/Assets/HoloToolkit/SpatialSound/Scripts/UAudioManager/UAudioManagerBase.cs
@@ -14,6 +14,7 @@ namespace HoloToolkit.Unity
     /// <remarks>The TEvent type specified must derive from AudioEvent.</remarks>
     public partial class UAudioManagerBase<TEvent> : MonoBehaviour where TEvent : AudioEvent, new()
     {
+#if UNITY_WSA
         [SerializeField]
         protected TEvent[] events = null;
 
@@ -671,5 +672,7 @@ namespace HoloToolkit.Unity
                 return Mathf.Max(0.0f, pitchAdjustedClipLength + activeEvent.audioEvent.instanceTimeBuffer + additionalDelay);
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialSound/Scripts/UAudioManager/UAudioMiniManager.cs
+++ b/Assets/HoloToolkit/SpatialSound/Scripts/UAudioManager/UAudioMiniManager.cs
@@ -10,6 +10,7 @@ namespace HoloToolkit.Unity
     /// </summary>
     public partial class UAudioMiniManager : UAudioManagerBase<MiniAudioEvent>
     {
+#if UNITY_WSA
         /// <summary>
         /// Plays all of the Audio Events in the manager
         /// </summary>
@@ -75,5 +76,7 @@ namespace HoloToolkit.Unity
                 events[i].primarySource.pitch = newPitch;
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstanding.cs
+++ b/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstanding.cs
@@ -15,6 +15,7 @@ namespace HoloToolkit.Unity
     [RequireComponent(typeof(SpatialUnderstandingCustomMesh))]
     public class SpatialUnderstanding : Singleton<SpatialUnderstanding>
     {
+#if UNITY_WSA
         // Consts
         public const float ScanSearchDistance = 8.0f;
 
@@ -253,5 +254,7 @@ namespace HoloToolkit.Unity
                 ScanState = ScanStates.Done;
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstandingCustomMesh.cs
+++ b/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstandingCustomMesh.cs
@@ -18,6 +18,7 @@ namespace HoloToolkit.Unity
     /// </summary>
     public class SpatialUnderstandingCustomMesh : SpatialMappingSource
     {
+#if UNITY_WSA
         // Config
         [Tooltip("Indicate the time in seconds between mesh imports, during the scanning phase. A value of zero will disable pulling meshes from the dll")]
         public float ImportMeshPeriod = 1.0f;
@@ -370,6 +371,8 @@ namespace HoloToolkit.Unity
         {
             Cleanup();
         }
+#endif
     }
 
 }
+

--- a/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstandingDll.cs
+++ b/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstandingDll.cs
@@ -18,6 +18,7 @@ namespace HoloToolkit.Unity
     /// </summary>
     public class SpatialUnderstandingDll
     {
+#if UNITY_WSA
         /// <summary>
         /// Representation of the mesh data to be passed to the understanding dll.
         /// Used by SpatialUnderstandingSourceMesh to store local copies of the mesh data.
@@ -574,5 +575,7 @@ namespace HoloToolkit.Unity
             }
 #endif
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstandingDllObjectPlacement.cs
+++ b/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstandingDllObjectPlacement.cs
@@ -15,6 +15,7 @@ namespace HoloToolkit.Unity
     /// </summary>
     public static class SpatialUnderstandingDllObjectPlacement
     {
+#if UNITY_WSA
         /// <summary>
         /// Defines an object placement query. A query consists of
         /// a type a name, type, set of rules, and set of constraints.
@@ -535,5 +536,7 @@ namespace HoloToolkit.Unity
         {
         }
 #endif
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstandingDllShapes.cs
+++ b/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstandingDllShapes.cs
@@ -22,6 +22,7 @@ namespace HoloToolkit.Unity
     /// </summary>
     public static class SpatialUnderstandingDllShapes
     {
+#if UNITY_WSA
         /// <summary>
         /// Result structure returned by shape queries
         /// </summary>
@@ -935,5 +936,7 @@ namespace HoloToolkit.Unity
         {
         }
 #endif
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstandingDllTopology.cs
+++ b/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstandingDllTopology.cs
@@ -15,6 +15,7 @@ namespace HoloToolkit.Unity
     /// </summary>
     public static class SpatialUnderstandingDllTopology
     {
+#if UNITY_WSA
         /// <summary>
         /// Result of a topology query. Typically results return an array 
         /// of these structures.
@@ -185,6 +186,8 @@ namespace HoloToolkit.Unity
             return 0;
         }
 #endif
+#endif
     }
 
 }
+

--- a/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstandingSourceMesh.cs
+++ b/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstandingSourceMesh.cs
@@ -17,6 +17,7 @@ namespace HoloToolkit.Unity
     /// </summary>
     public class SpatialUnderstandingSourceMesh : MonoBehaviour
     {
+#if UNITY_WSA
         // Privates
         /// <summary>
         /// Internal list of meshes that is passed to the dll. This is
@@ -151,5 +152,7 @@ namespace HoloToolkit.Unity
 
             return true;
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Utilities/Editor/ConfigureMenu.cs
+++ b/Assets/HoloToolkit/Utilities/Editor/ConfigureMenu.cs
@@ -18,6 +18,7 @@ namespace HoloToolkit.Unity
     
     public class AutoConfigureMenu : UnityEditor.EditorWindow
     {
+#if UNITY_WSA
 
         [MenuItem("HoloToolkit/Configure/Show Help", false, 3)]
         public static void ShowHelp()
@@ -251,6 +252,7 @@ application uses online services.");
             PlayerSettings.WSA.SetCapability(mCap, GUILayout.Toggle(PlayerSettings.WSA.GetCapability(mCap), new GUIContent(" " + mCap.ToString(), tooltip)));
         }
 
-
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Utilities/Editor/EditorGUIExtensions.cs
+++ b/Assets/HoloToolkit/Utilities/Editor/EditorGUIExtensions.cs
@@ -13,6 +13,7 @@ namespace HoloToolkit.Unity
     /// </summary>
     public class EditorGUIExtensions : MonoBehaviour
     {
+#if UNITY_WSA
         public static float Indent
         {
             get
@@ -173,5 +174,6 @@ namespace HoloToolkit.Unity
 
             return (T)objValue;
         }
-    }
+#endif
+	}
 }

--- a/Assets/HoloToolkit/Utilities/Editor/EditorGUILayoutExtensions.cs
+++ b/Assets/HoloToolkit/Utilities/Editor/EditorGUILayoutExtensions.cs
@@ -13,6 +13,7 @@ namespace HoloToolkit.Unity
     /// </summary>
     public static class EditorGUILayoutExtensions
     {
+#if UNITY_WSA
         public static bool Button(string text, params GUILayoutOption[] options)
         {
             return Button(text, GUI.skin.button, options);
@@ -75,5 +76,7 @@ namespace HoloToolkit.Unity
 
             return (T)objValue;
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Utilities/Editor/EnforceEditorSettings.cs
+++ b/Assets/HoloToolkit/Utilities/Editor/EnforceEditorSettings.cs
@@ -8,6 +8,7 @@ namespace HoloToolKit.Unity
     [InitializeOnLoad]
     public class EnforceEditorSettings
     {
+#if UNITY_WSA
         static EnforceEditorSettings()
         {
             #region Editor Settings
@@ -26,5 +27,7 @@ namespace HoloToolKit.Unity
 
             #endregion
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Utilities/Editor/LayerMaskExtensions.cs
+++ b/Assets/HoloToolkit/Utilities/Editor/LayerMaskExtensions.cs
@@ -11,6 +11,7 @@ namespace HoloToolkit.Unity
     /// </summary>
     public static class LayerMaskExtensions
     {
+#if UNITY_WSA
         public const int LayerCount = 32;
 
         private static string[] layerMaskNames = null;
@@ -53,5 +54,7 @@ namespace HoloToolkit.Unity
 
             return stringBuilder == null ? "None" : stringBuilder.ToString();
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Utilities/Scripts/Billboard.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Billboard.cs
@@ -19,6 +19,7 @@ namespace HoloToolkit.Unity
     /// </summary>
     public class Billboard : MonoBehaviour
     {
+#if UNITY_WSA
         /// <summary>
         /// The axis about which the object will rotate.
         /// </summary>
@@ -65,5 +66,7 @@ namespace HoloToolkit.Unity
             // Calculate and apply the rotation required to reorient the object
             transform.rotation = Quaternion.LookRotation(-directionToTarget);
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Utilities/Scripts/DirectionIndicator.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/DirectionIndicator.cs
@@ -11,6 +11,7 @@ namespace HoloToolkit.Unity
     /// </summary>
     public class DirectionIndicator : MonoBehaviour
     {
+#if UNITY_WSA
         [Tooltip("The Cursor object the direction indicator will be positioned around.")]
         public GameObject Cursor;
 
@@ -164,5 +165,7 @@ namespace HoloToolkit.Unity
                 Camera.main.transform.forward,
                 cursorIndicatorDirection) * directionIndicatorDefaultRotation;
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Utilities/Scripts/Extensions/ActionExtensions.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Extensions/ActionExtensions.cs
@@ -11,6 +11,7 @@ namespace HoloToolkit.Unity
     /// </summary>
     public static class ActionExtensions
     {
+#if UNITY_WSA
         public static void RaiseEvent(this Action action)
         {
             if (action != null)
@@ -50,5 +51,7 @@ namespace HoloToolkit.Unity
                 action(arg1, arg2, arg3, arg4);
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Utilities/Scripts/Extensions/ComponentExtensions.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Extensions/ComponentExtensions.cs
@@ -13,6 +13,7 @@ namespace HoloToolkit.Unity
     /// </summary>
     public static class ComponentExtensions
     {
+#if UNITY_WSA
         /// <summary>
         /// Ensure that a component of type <typeparamref name="T"/> exists on the game object.
         /// If it doesn't exist, creates it.
@@ -134,5 +135,7 @@ namespace HoloToolkit.Unity
                 action(i);
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Utilities/Scripts/Extensions/Extensions.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Extensions/Extensions.cs
@@ -1,6 +1,5 @@
-﻿//
-// Copyright (C) Microsoft. All rights reserved.
-//
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using UnityEngine;
 
@@ -11,6 +10,7 @@ namespace HoloToolkit.Unity
     /// </summary>
     public static class Extensions
     {
+#if UNITY_WSA
         /// <summary>
         /// Returns the absolute duration of the curve from first to last key frame
         /// </summary>
@@ -25,5 +25,7 @@ namespace HoloToolkit.Unity
 
             return Mathf.Abs(curve[curve.length - 1].time - curve[0].time);
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Utilities/Scripts/Extensions/TransformExtensions.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Extensions/TransformExtensions.cs
@@ -8,6 +8,7 @@ namespace HoloToolkit.Unity
 {
     public static class TransformExtensions
     {
+#if UNITY_WSA
         /// <summary>
         /// An extension method that will get you the full path to an object.
         /// </summary>
@@ -32,5 +33,7 @@ namespace HoloToolkit.Unity
 
             return stringBuilder.ToString();
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Utilities/Scripts/Extensions/VectorExtensions.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Extensions/VectorExtensions.cs
@@ -12,6 +12,7 @@ namespace HoloToolkit.Unity
     /// </summary>
     public static class VectorExtensions
     {
+#if UNITY_WSA
         public static Vector2 Mul(this Vector2 value, Vector2 scale)
         {
             return new Vector2(value.x * scale.x, value.y * scale.y);
@@ -164,5 +165,7 @@ namespace HoloToolkit.Unity
 
             return vectors.OrderBy(v => v.sqrMagnitude).ElementAt(count / 2);
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Utilities/Scripts/FixedAngularSize.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/FixedAngularSize.cs
@@ -12,6 +12,7 @@ namespace HoloToolkit.Unity
     /// </summary>
     public class FixedAngularSize : MonoBehaviour
     {
+#if UNITY_WSA
         [Tooltip("Off sets the scale ratio so that text does not scale down too much. (Set to zero for linear scaling)")]
         public float SizeRatio = 0;
 
@@ -69,5 +70,7 @@ namespace HoloToolkit.Unity
             float curvedRatio = 1 - startingDistance * SizeRatio;
             transform.localScale = startingScale * (distanceToHologram * SizeRatio + curvedRatio);
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Utilities/Scripts/FpsDisplay.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/FpsDisplay.cs
@@ -11,6 +11,7 @@ namespace HoloToolkit.Unity
     [RequireComponent(typeof(TextMesh))]
     public class FpsDisplay : MonoBehaviour
     {
+#if UNITY_WSA
         [Tooltip("Reference to Text UI control where the FPS should be displayed.")]
         [SerializeField]
         private TextMesh textMesh;
@@ -96,5 +97,7 @@ namespace HoloToolkit.Unity
 
             averageFps = sum / frameRange;
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Utilities/Scripts/HeadsUpDirectionIndicator.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/HeadsUpDirectionIndicator.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 using UnityEngine;
 
 namespace HoloToolkit.Unity
@@ -13,6 +16,7 @@ namespace HoloToolkit.Unity
     // object according to that assumption.
     public class HeadsUpDirectionIndicator : MonoBehaviour
     {
+#if UNITY_WSA
         // Use as a named indexer for Unity's frustum planes. The order follows that layed
         // out in the API documentation. DO NOT CHANGE ORDER unless a corresponding change
         // has been made in the Unity API.
@@ -363,5 +367,7 @@ namespace HoloToolkit.Unity
             indicatorVolume[4] = frustumPlanes[4];
             indicatorVolume[5] = frustumPlanes[5];
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Utilities/Scripts/InterpolationUtilities.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/InterpolationUtilities.cs
@@ -10,6 +10,7 @@ namespace HoloToolkit.Unity
     /// </summary>
     public static class InterpolationUtilities
     {
+#if UNITY_WSA
         #region Exponential Decay
 
         public static float ExpDecay(float from, float to, float hLife, float dTime)
@@ -47,5 +48,7 @@ namespace HoloToolkit.Unity
         }
 
         #endregion
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Utilities/Scripts/Interpolator.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Interpolator.cs
@@ -10,7 +10,8 @@ namespace HoloToolkit.Unity
     /// </summary>
     public class Interpolator : MonoBehaviour
     {
-        // A very small number that is used in determining if the Interpolator
+ #if UNITY_WSA
+       // A very small number that is used in determining if the Interpolator
         // needs to run at all.
         private const float smallNumber = 0.0000001f;
 
@@ -503,5 +504,7 @@ namespace HoloToolkit.Unity
                 return transform.localScale;
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Utilities/Scripts/NearPlaneFade.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/NearPlaneFade.cs
@@ -8,6 +8,7 @@ namespace HoloToolkit.Unity
     [ExecuteInEditMode]
     public class NearPlaneFade : MonoBehaviour
     {
+#if UNITY_WSA
         public float FadeDistanceStart = 0.85f;
         public float FadeDistanceEnd = 0.5f;
 
@@ -48,5 +49,7 @@ namespace HoloToolkit.Unity
                 Shader.DisableKeyword(FadeKeywordOn);
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Utilities/Scripts/PriorityQueue.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/PriorityQueue.cs
@@ -253,3 +253,4 @@ namespace HoloToolkit.Unity
         }
     }
 }
+

--- a/Assets/HoloToolkit/Utilities/Scripts/RollingStatistics.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/RollingStatistics.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
+
 using UnityEngine;
 
 namespace HoloToolkit.Unity
 {
     public class VectorRollingStatistics
     {
+#if UNITY_WSA
         /// <summary>
         /// Current standard deviation of the positions of the vectors
         /// </summary>
@@ -139,5 +141,7 @@ namespace HoloToolkit.Unity
             // update the next list position
             currentSampleIndex = (currentSampleIndex + 1) % maxSamples;
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Utilities/Scripts/SimpleTagalong.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/SimpleTagalong.cs
@@ -12,6 +12,7 @@ namespace HoloToolkit.Unity
     [RequireComponent(typeof(BoxCollider), typeof(Interpolator))]
     public class SimpleTagalong : MonoBehaviour
     {
+#if UNITY_WSA
         // Simple Tagalongs seek to stay at a fixed distance from the Camera.
         [Tooltip("The distance in meters from the camera for the Tagalong to seek when updating its position.")]
         public float TagalongDistance = 2.0f;
@@ -176,5 +177,7 @@ namespace HoloToolkit.Unity
             // If we got here, needsToMove will be true.
             return needsToMove;
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Utilities/Scripts/Singleton.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Singleton.cs
@@ -11,6 +11,7 @@ namespace HoloToolkit.Unity
     /// <typeparam name="T"></typeparam>
     public class Singleton<T> : MonoBehaviour where T : Singleton<T>
     {
+#if UNITY_WSA
         private static T instance;
         public static T Instance
         {
@@ -53,5 +54,7 @@ namespace HoloToolkit.Unity
                 instance = null;
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Utilities/Scripts/SphereBasedTagalong.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/SphereBasedTagalong.cs
@@ -11,6 +11,7 @@ namespace HoloToolkit.Unity
     /// </summary>
     public class SphereBasedTagalong : MonoBehaviour
     {
+#if UNITY_WSA
         [Tooltip("Sphere radius.")]
         public float SphereRadius = 1.0f;
 
@@ -64,5 +65,7 @@ namespace HoloToolkit.Unity
 
             Gizmos.color = oldColor;
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Utilities/Scripts/StabilizationPlaneModifier.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/StabilizationPlaneModifier.cs
@@ -12,6 +12,7 @@ namespace HoloToolkit.Unity
     /// </summary>
     public class StabilizationPlaneModifier : Singleton<StabilizationPlaneModifier>
     {
+#if UNITY_WSA
         [Tooltip("Checking enables SetFocusPointForFrame to set the stabilization plane.")]
         public bool SetStabilizationPlane = true;
         [Tooltip("Lerp speed when moving focus point closer.")]
@@ -214,5 +215,7 @@ namespace HoloToolkit.Unity
                 Gizmos.DrawCube(Vector3.zero, Vector3.one);
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Utilities/Scripts/Tagalong.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Tagalong.cs
@@ -13,6 +13,7 @@ namespace HoloToolkit.Unity
     /// </summary>
     public class Tagalong : SimpleTagalong
     {
+#if UNITY_WSA
         // These members allow for specifying target and minimum percentage in
         // the FOV.
         [Range(0.0f, 1.0f), Tooltip("The minimum horizontal percentage visible before the object starts tagging along.")]
@@ -397,5 +398,7 @@ namespace HoloToolkit.Unity
             DebugDrawLine(draw, cameraPosition, calculatedPosition, Color.cyan);
         }
 #endif // UNITY_EDITOR
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Utilities/Scripts/TextToSpeechManager.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/TextToSpeechManager.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
+
 using System;
 using UnityEngine;
 
@@ -52,6 +53,7 @@ namespace HoloToolkit.Unity
     /// </remarks>
     public class TextToSpeechManager : MonoBehaviour
     {
+#if UNITY_WSA
         // Inspector Variables
         [Tooltip("The audio source where speech will be played.")]
         [SerializeField]
@@ -418,5 +420,7 @@ namespace HoloToolkit.Unity
         /// Gets or sets the voice that will be used to generate speech.
         /// </summary>
         public TextToSpeechVoice Voice { get { return voice; } set { voice = value; } }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Utilities/Scripts/Timer.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Timer.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
+#if UNITY_WSA
 
 namespace HoloToolkit.Unity
 {
@@ -55,3 +56,5 @@ namespace HoloToolkit.Unity
         }
     }
 }
+
+#endif

--- a/Assets/HoloToolkit/Utilities/Scripts/TimerScheduler.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/TimerScheduler.cs
@@ -32,6 +32,7 @@ namespace HoloToolkit.Unity
     /// </example>
     public sealed class TimerScheduler : Singleton<TimerScheduler>
     {
+#if UNITY_WSA
         private struct TimerData
         {
             public Callback Callback;
@@ -239,5 +240,7 @@ namespace HoloToolkit.Unity
         {
             return GetActiveTimerIndex(timerId.Id) > -1 || GetTimerDeferredIndex(timerId.Id) > -1;
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Utilities/Scripts/WorldAnchorManager.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/WorldAnchorManager.cs
@@ -14,6 +14,7 @@ namespace HoloToolkit.Unity
     /// </summary>
     public class WorldAnchorManager : Singleton<WorldAnchorManager>
     {
+#if UNITY_WSA
         /// <summary>
         /// To prevent initializing too many anchors at once
         /// and to allow for the WorldAnchorStore to load asyncronously
@@ -214,5 +215,7 @@ namespace HoloToolkit.Unity
                 Debug.LogError(gameObject.name + " : World anchor save failed.");
             }
         }
+#endif
     }
 }
+

--- a/Assets/HoloToolkit/Utilities/Tests/Scripts/GestureResponder.cs
+++ b/Assets/HoloToolkit/Utilities/Tests/Scripts/GestureResponder.cs
@@ -1,8 +1,12 @@
-﻿using UnityEngine;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
 using HoloToolkit.Unity.InputModule;
 
 public class GestureResponder : MonoBehaviour, IInputClickHandler
 {
+#if UNITY_WSA
     private void Start()
     {
         InputManager.Instance.PushFallbackInputHandler(gameObject);
@@ -12,4 +16,6 @@ public class GestureResponder : MonoBehaviour, IInputClickHandler
     {
         PlaneTargetGroupPicker.Instance.PickNewTarget();
     }
+#endif
 }
+

--- a/Assets/HoloToolkit/Utilities/Tests/Scripts/PlaneTargetGroup.cs
+++ b/Assets/HoloToolkit/Utilities/Tests/Scripts/PlaneTargetGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using UnityEngine;
@@ -6,6 +6,7 @@ using System.Collections;
 
 public class PlaneTargetGroup : MonoBehaviour
 {
+#if UNITY_WSA
     [Tooltip("Enter in same target consecutively to turn on velocity tracking for that target.")]
     public Transform[] Targets;
     
@@ -52,4 +53,6 @@ public class PlaneTargetGroup : MonoBehaviour
         }
         CurrentTarget = newTarget;
     }
+#endif
 }
+

--- a/Assets/HoloToolkit/Utilities/Tests/Scripts/PlaneTargetGroupPicker.cs
+++ b/Assets/HoloToolkit/Utilities/Tests/Scripts/PlaneTargetGroupPicker.cs
@@ -1,4 +1,4 @@
-﻿// Copyright Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using UnityEngine;
@@ -7,6 +7,7 @@ using HoloToolkit.Unity;
 
 public class PlaneTargetGroupPicker : Singleton<PlaneTargetGroupPicker>
 {
+#if UNITY_WSA
     [Tooltip("In degrees")]
     public float AngleOfAcceptance = 45.0f;
     public PlaneTargetGroup[] Groups;
@@ -70,4 +71,6 @@ public class PlaneTargetGroupPicker : Singleton<PlaneTargetGroupPicker>
         yield return new WaitForSeconds(displayTime);
         DisplayText.text = "";
     }
+#endif
 }
+

--- a/Assets/HoloToolkit/Utilities/Tests/Scripts/TextToSpeechManagerTest.cs
+++ b/Assets/HoloToolkit/Utilities/Tests/Scripts/TextToSpeechManagerTest.cs
@@ -1,4 +1,7 @@
-﻿using UnityEngine;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
 using System.Collections;
 using UnityEngine.VR.WSA.Input;
 using UnityEngine.Windows.Speech;
@@ -8,6 +11,7 @@ using HoloToolkit.Unity.InputModule;
 
 public class TextToSpeechManagerTest : MonoBehaviour
 {
+#if UNITY_WSA
     private GestureRecognizer gestureRecognizer;
     public TextToSpeechManager textToSpeechManager;
 
@@ -61,4 +65,6 @@ public class TextToSpeechManagerTest : MonoBehaviour
         // This voice will appear to follow the user.
         textToSpeechManager.SpeakText("The time is " + DateTime.Now.ToString("t"));
     }
+#endif
 }
+

--- a/Assets/HoloToolkit/Utilities/Tests/Scripts/TextToSpeechOnTap.cs
+++ b/Assets/HoloToolkit/Utilities/Tests/Scripts/TextToSpeechOnTap.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using UnityEngine;
 using HoloToolkit.Unity.InputModule;
 
@@ -6,6 +9,7 @@ namespace HoloToolkit.Unity.Tests
 {
     public class TextToSpeechOnTap : MonoBehaviour, IInputClickHandler
     {
+#if UNITY_WSA
         public TextToSpeechManager TextToSpeech;
 
         public void OnInputClicked(InputEventData eventData)
@@ -24,5 +28,7 @@ namespace HoloToolkit.Unity.Tests
                 TextToSpeech.SpeakText(msg);
             }
         }
+#endif
     }
 }
+


### PR DESCRIPTION
See https://github.com/Microsoft/HoloToolkit-Unity/issues/387

Prior to this PR, including HoloToolkit-Unity in a cross-platform Unity project would break all non-Windows Store (UNITY_WSA) platforms. This commit wraps the toolkit code in #if UNITY_WSA blocks to allow inclusion in cross-platform projects. There are a huge number of files in the project so this PR undoubtedly #if's out code that could safely be included in other platforms but at least it no longer takes down other platforms when included in projects. 

There are zero functional changes in this PR other than wrapping code in #if UNITY_WSA blocks and changing a couple #if UNITY_METRO's to #if UNITY_WSA (UNITY_METRO is a deprecated #define for the code paths now referred to as UNITY_WSA).

As part of adding these changes, I started out by adding all the #if/#endif pairs at the top and bottom of the files, which led me to spot and correct a number of files that were missing standard Microsoft copyright comment blocks. After making that first pass at doing the outermost wrapping of the code, I realized that the #if's needed to be moved inside the MonoBehaviour class definitions so behaviors added to GameObjects in the editor would remain visible and connected to the objects when the build platform changed. Moving the #if's inside the MonoBehaviour class definitions forced many/most of the misc. classes in the project to be treated the same way (because they were involved as interfaces or generics in the MonoBehaviour-derived class declarations). This led me to do a pass moving all the #if UNITY_WSA's just inside the class definitions for all the classes. And *that* led to a final pass where a few of the classes needed hand-tweaked inner exclusions to prevent missing interface members and contained structs/classes from breaking the build. 

There was a large set of files that were auto-generated using SWIG (https://github.com/Microsoft/HoloToolkit-Unity/search?utf8=%E2%9C%93&q=swig). These files contained a standard banner heading indicating they were auto-generated and should not be modified directly, so I didn't. Fortunately their presence doesn't appear to impact the cross-platform compatibility of the toolkit.

At this point the modified Toolkit can be included in cross-platform projects without breaking the build.