### PR TITLE
The check for a VR device does not happen at run time.

### DIFF
--- a/Assets/HoloToolkit/SpatialMapping/Scripts/SpatialMappingManager.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/SpatialMappingManager.cs
@@ -202,7 +202,7 @@ namespace HoloToolkit.Unity.SpatialMapping
         /// </summary>
         public void StopObserver()
         {
-#if UNITY_EDITOR
+#if UNITY_EDITOR || UNITY_UWP
             // Allow observering if a device is present (Holographic Remoting)
             if (!UnityEngine.VR.VRDevice.isPresent) return;
 #endif

--- a/Assets/HoloToolkit/SpatialMapping/Scripts/SpatialMappingManager.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/SpatialMappingManager.cs
@@ -186,7 +186,7 @@ namespace HoloToolkit.Unity.SpatialMapping
         /// </summary>
         public void StartObserver()
         {
-#if UNITY_EDITOR
+#if UNITY_EDITOR || UNITY_UWP
             // Allow observering if a device is present (Holographic Remoting)
             if (!UnityEngine.VR.VRDevice.isPresent) return;
 #endif


### PR DESCRIPTION
If the app runs of a Windows 10 device that is NOT a HoloLens, it will will crash. This happens for instance when the Windows App Certification Kit runs. Result: the WACK lists a boatload of errors that will never happen when the app is actually deployed to a HoloLens, causing confusing for developers. Also, it prevents the app from running on a normal PC.