### PR TITLE
prevent cursor from disappearing on manipulation cancel

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
@@ -418,7 +418,7 @@ namespace HoloToolkit.Unity.InputModule
         {
             if (cursorState != CursorStateEnum.Contextual)
             {
-                if (IsInputSourceDown && visibleHandsCount > 0)
+                if (IsInputSourceDown)
                 {
                     return CursorStateEnum.Select;
                 }

--- a/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
@@ -395,6 +395,7 @@ namespace HoloToolkit.Unity.InputModule
             if (visibleHandsCount == 0)
             {
                 IsHandVisible = false;
+                IsInputSourceDown = false;
             }
         }
 
@@ -420,10 +421,6 @@ namespace HoloToolkit.Unity.InputModule
                 if (IsInputSourceDown && visibleHandsCount > 0)
                 {
                     return CursorStateEnum.Select;
-                }
-                else if (IsInputSourceDown && visibleHandsCount == 0)
-                {
-                  IsInputSourceDown = false;
                 }
                 else if (cursorState == CursorStateEnum.Select)
                 {

--- a/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
@@ -417,9 +417,13 @@ namespace HoloToolkit.Unity.InputModule
         {
             if (cursorState != CursorStateEnum.Contextual)
             {
-                if (IsInputSourceDown)
+                if (IsInputSourceDown && visibleHandsCount > 0)
                 {
                     return CursorStateEnum.Select;
+                }
+                else if (IsInputSourceDown && visibleHandsCount == 0)
+                {
+                  IsInputSourceDown = false;
                 }
                 else if (cursorState == CursorStateEnum.Select)
                 {


### PR DESCRIPTION
Resolves #445 by adding additional checks to determine cursor state.
The first one essentially says that `IsInputSourceDown` should be `true` and visible hands should be greater than one to say that cursor is in a select state.  The second if statement is to mend the case where `IsInputSourceDown` happens to be true while no hands are visible, in which case we set `IsInputSourceDown` to false.