### PR TITLE
Update to Unity 5.5.1f1

### DIFF
--- a/Assets/HoloToolkit/Utilities/Shaders/FastConfigurable.shader.meta
+++ b/Assets/HoloToolkit/Utilities/Shaders/FastConfigurable.shader.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a82e601d90c076c458969fbd127780e6
+guid: f1f3948b20c230044bda31b620ddd37f
 timeCreated: 1480619515
 licenseType: Pro
 ShaderImporter:

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -191,6 +191,9 @@ PlayerSettings:
   iOSBackgroundModes: 0
   iOSMetalForceHardShadows: 0
   appleDeveloperTeamID: 
+  iOSManualSigningProvisioningProfileID: 
+  tvOSManualSigningProvisioningProfileID: 
+  appleEnableAutomaticSigning: 0
   AndroidTargetDevice: 0
   AndroidSplashScreenScale: 0
   androidSplashScreen: {fileID: 0}
@@ -321,6 +324,7 @@ PlayerSettings:
   ps4ParamSfxPath: 
   ps4VideoOutPixelFormat: 0
   ps4VideoOutInitialWidth: 1920
+  ps4VideoOutBaseModeInitialWidth: 1920
   ps4VideoOutReprojectionRate: 120
   ps4PronunciationXMLPath: 
   ps4PronunciationSIGPath: 
@@ -343,6 +347,7 @@ PlayerSettings:
   ps4ApplicationParam4: 0
   ps4DownloadDataSize: 0
   ps4GarlicHeapSize: 2048
+  ps4ProGarlicHeapSize: 2560
   ps4Passcode: frAQBc8Wsa1xVPfvJcrgRYwTiizs2trQ
   ps4UseDebugIl2cppLibs: 0
   ps4pnSessions: 1
@@ -368,6 +373,9 @@ PlayerSettings:
   ps4attribShareSupport: 0
   ps4attribExclusiveVR: 0
   ps4disableAutoHideSplash: 0
+  ps4videoRecordingFeaturesUsed: 0
+  ps4contentSearchFeaturesUsed: 0
+  ps4attribEyeToEyeDistanceSettingVR: 0
   ps4IncludedModules: []
   monoEnv: 
   psp2Splashimage: {fileID: 0}

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 5.5.0f3
+m_EditorVersion: 5.5.1f1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This is effectively part of the existing HoloToolkit, but this is the repository that will contain all Unity specific components.
 The HoloToolkit is a collection of scripts and components intended to accelerate development of holographic applications targeting Windows Holographic.
 
-**Current Unity Editor Project Version: 5.5.0f3**
+**Current Unity Editor Project Version: 5.5.1f1**
 
 HoloToolkit contains the following feature areas:
 


### PR DESCRIPTION
Resolves https://github.com/Microsoft/HoloToolkit-Unity/issues/475

https://unity3d.com/unity/whats-new/unity-5.5.1

**Caution!**
> - Warning about missing object references in the inspector after upgraded to 5.5. We have only received one bug report and we have not been able to reproduce the issue. If you find some/all of your object references missing in the inspector do not save your scene. Quit the editor and re-open your project and the references should come back correctly.

HoloLens Specific Improvements:

> - AR: Fixed a crash when exiting play mode during a Holographic Simulation session. (858208)
> - HoloLens: Fixed a crash in Editor when terminating Remoting App during an active Holographic Remoting session.
> - HoloLens: Fixed resume-from-suspend bugs that would occasionally crash the app or not render anything. (800796, 851897, 825951)
> - HoloLens: Improved error reporting when failing to load PerceptionRemotingPlugin.dll (used by Holographic Remoting). (848237)
> - Core: Fixed hangs in the job system when running on certain platforms with a low number of cores e.g. older Windows Phones, UWP dual core machines. (791434)
> - Shaders: Optimized in-editor import, load time and memory usage for shaders with massive amounts of potential variants.