### PR TITLE
fixed Unity error caused by missing MonoBehaviour

### DIFF
--- a/Assets/HoloToolkit/Sharing/Scripts/SessionUsersTracker.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/SessionUsersTracker.cs
@@ -10,7 +10,7 @@ namespace HoloToolkit.Sharing
     /// <summary>
     /// Keeps track of the users in the current session.
     /// </summary>
-    public class SessionUsersTracker : IDisposable
+	public class SessionUsersTracker : MonoBehaviour, IDisposable
     {
         /// <summary>
         /// UserJoined event notifies when a user joins the current session.

--- a/Assets/HoloToolkit/Sharing/Scripts/SessionUsersTracker.cs
+++ b/Assets/HoloToolkit/Sharing/Scripts/SessionUsersTracker.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using HoloToolkit.Unity;
+using UnityEngine;
 
 namespace HoloToolkit.Sharing
 {


### PR DESCRIPTION
The missing MonoBehaviour caused an error in Unity.

