### PR TITLE
Fix rotation if hologram was rotated before

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Interactions/HandDraggable.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Interactions/HandDraggable.cs
@@ -44,6 +44,7 @@ namespace HoloToolkit.Unity.InputModule
         private bool isDragging;
         private bool isGazed;
         private Vector3 objRefForward;
+        private Vector3 objRefUp;
         private float objRefDistance;
         private Quaternion gazeAngularOffset;
         private float handRefDistance;
@@ -117,6 +118,7 @@ namespace HoloToolkit.Unity.InputModule
             objRefDistance = Vector3.Magnitude(gazeHitPosition - pivotPosition);
 
             Vector3 objForward = HostTransform.forward;
+            Vector3 objUp = HostTransform.up;
 
             // Store where the object was grabbed from
             objRefGrabPoint = mainCamera.transform.InverseTransformDirection(HostTransform.position - gazeHitPosition);
@@ -125,10 +127,12 @@ namespace HoloToolkit.Unity.InputModule
             Vector3 handDirection = Vector3.Normalize(handPosition - pivotPosition);
 
             objForward = mainCamera.transform.InverseTransformDirection(objForward);       // in camera space
+            objUp = mainCamera.transform.InverseTransformDirection(objUp);       		   // in camera space
             objDirection = mainCamera.transform.InverseTransformDirection(objDirection);   // in camera space
             handDirection = mainCamera.transform.InverseTransformDirection(handDirection); // in camera space
 
             objRefForward = objForward;
+            objRefUp = objUp;
 
             // Store the initial offset between the hand and the object, so that we can consider it when dragging
             gazeAngularOffset = Quaternion.FromToRotation(handDirection, objDirection);
@@ -197,7 +201,8 @@ namespace HoloToolkit.Unity.InputModule
             else
             {
                 Vector3 objForward = mainCamera.transform.TransformDirection(objRefForward); // in world space
-                draggingRotation = Quaternion.LookRotation(objForward);
+                Vector3 objUp = mainCamera.transform.TransformDirection(objRefUp);   // in world space
+                draggingRotation = Quaternion.LookRotation(objForward, objUp);
             }
 
             // Apply Final Position


### PR DESCRIPTION
Since the up vector was ignored, the dragging function always messed up with the rotation of a object if it was rotated before.
Quaternion.LookRotation() takes the global up vector (Y) by default,  but if the object was rotated for example around the Z axis, the global up vector isn't the same as the local one -> object rotation is messed up, because the local forward vector and the global up vector are used instead of local forward and local up.