### PR TITLE
Need to update collision mesh when committing mesh data

### DIFF
--- a/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstandingCustomMesh.cs
+++ b/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstandingCustomMesh.cs
@@ -98,6 +98,11 @@ namespace HoloToolkit.Unity
             public readonly Mesh MeshObject = new Mesh();
 
             /// <summary>
+            /// The MeshCollider with which this mesh is associated.
+            /// </summary>
+            public MeshCollider Collider = null;
+
+            /// <summary>
             /// Clears the geometry, but does not clear the mesh.
             /// </summary>
             public void Reset()
@@ -118,6 +123,11 @@ namespace HoloToolkit.Unity
                     MeshObject.SetTriangles(tris, 0);
                     MeshObject.RecalculateNormals();
                     MeshObject.RecalculateBounds();
+                    if (Collider)
+                    {
+                      Collider.sharedMesh = null;
+                      Collider.sharedMesh = MeshObject;
+                    }
                 }
             }
 
@@ -183,13 +193,16 @@ namespace HoloToolkit.Unity
 
                 int surfaceObjectIndex = SurfaceObjects.Count;
 
-                AddSurfaceObject(CreateSurfaceObject(
-                    mesh: nextSectorData.MeshObject,
-                    objectName: string.Format("SurfaceUnderstanding Mesh-{0}", surfaceObjectIndex),
-                    parentObject: transform,
-                    meshID: surfaceObjectIndex,
-                    drawVisualMeshesOverride: DrawProcessedMesh
-                    ));
+                SurfaceObject surfaceObject = CreateSurfaceObject(
+                  mesh: nextSectorData.MeshObject,
+                  objectName: string.Format("SurfaceUnderstanding Mesh-{0}", surfaceObjectIndex),
+                  parentObject: transform,
+                  meshID: surfaceObjectIndex,
+                  drawVisualMeshesOverride: DrawProcessedMesh);
+
+                nextSectorData.Collider = surfaceObject.Collider;
+
+                AddSurfaceObject(surfaceObject);
 
                 // Or make it if this is a new sector.
                 meshSectors.Add(sector, nextSectorData);

--- a/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstandingCustomMesh.cs
+++ b/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstandingCustomMesh.cs
@@ -33,6 +33,11 @@ namespace HoloToolkit.Unity
             get { return (MaxFrameTime / 1000); }
         }
 
+        /// <summary>
+        ///  Whether to create mesh colliders. If unchecked, mesh colliders will be empty and disabled.
+        /// </summary>
+        public bool CreateMeshColliders = true;
+
         private bool drawProcessedMesh = true;
         // Properties
         /// <summary>
@@ -98,9 +103,16 @@ namespace HoloToolkit.Unity
             public readonly Mesh MeshObject = new Mesh();
 
             /// <summary>
-            /// The MeshCollider with which this mesh is associated.
+            /// The MeshCollider with which this mesh is associated. Must be set even if
+            /// no collision mesh will be created.
             /// </summary>
             public MeshCollider SpatialCollider = null;
+
+            /// <summary>
+            /// Whether to create collision mesh. If false, the MeshCollider attached to this
+            /// object will also be disabled when Commit() is called.
+            /// </summary>
+            public bool CreateMeshCollider = false;
 
             /// <summary>
             /// Clears the geometry, but does not clear the mesh.
@@ -125,7 +137,15 @@ namespace HoloToolkit.Unity
                     MeshObject.RecalculateBounds();
                     // The null assignment is required by Unity in order to pick up the new mesh
                     SpatialCollider.sharedMesh = null;
-                    SpatialCollider.sharedMesh = MeshObject;
+                    if (CreateMeshCollider)
+                    {
+                        SpatialCollider.sharedMesh = MeshObject;
+                        SpatialCollider.enabled = true;
+                    }
+                    else
+                    {
+                        SpatialCollider.enabled = false;
+                    }
                 }
             }
 
@@ -188,6 +208,7 @@ namespace HoloToolkit.Unity
             if (!meshSectors.TryGetValue(sector, out nextSectorData))
             {
                 nextSectorData = new MeshData();
+                nextSectorData.CreateMeshCollider = CreateMeshColliders;
 
                 int surfaceObjectIndex = SurfaceObjects.Count;
 

--- a/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstandingCustomMesh.cs
+++ b/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstandingCustomMesh.cs
@@ -100,7 +100,7 @@ namespace HoloToolkit.Unity
             /// <summary>
             /// The MeshCollider with which this mesh is associated.
             /// </summary>
-            public MeshCollider Collider = null;
+            public MeshCollider SpatialCollider = null;
 
             /// <summary>
             /// Clears the geometry, but does not clear the mesh.
@@ -123,11 +123,8 @@ namespace HoloToolkit.Unity
                     MeshObject.SetTriangles(tris, 0);
                     MeshObject.RecalculateNormals();
                     MeshObject.RecalculateBounds();
-                    if (Collider)
-                    {
-                      Collider.sharedMesh = null;
-                      Collider.sharedMesh = MeshObject;
-                    }
+                    SpatialCollider.sharedMesh = null;
+                    SpatialCollider.sharedMesh = MeshObject;
                 }
             }
 
@@ -200,7 +197,7 @@ namespace HoloToolkit.Unity
                   meshID: surfaceObjectIndex,
                   drawVisualMeshesOverride: DrawProcessedMesh);
 
-                nextSectorData.Collider = surfaceObject.Collider;
+                nextSectorData.SpatialCollider = surfaceObject.Collider;
 
                 AddSurfaceObject(surfaceObject);
 

--- a/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstandingCustomMesh.cs
+++ b/Assets/HoloToolkit/SpatialUnderstanding/Scripts/SpatialUnderstandingCustomMesh.cs
@@ -123,6 +123,7 @@ namespace HoloToolkit.Unity
                     MeshObject.SetTriangles(tris, 0);
                     MeshObject.RecalculateNormals();
                     MeshObject.RecalculateBounds();
+                    // The null assignment is required by Unity in order to pick up the new mesh
                     SpatialCollider.sharedMesh = null;
                     SpatialCollider.sharedMesh = MeshObject;
                 }


### PR DESCRIPTION
There appears to be a bug with SpatialUnderstandingCustomMesh: when finalizing the mesh data (with Commit()), the rendering mesh picks up the changes but the collision mesh does not. Presumably this is a quirk of how Unity handles collision meshes.

The result of this is that using meshes produced by the Spatial Understanding system (as opposed to the underlying meshes provided by SpatialMappingManager) doesn't work in scenarios where rigid bodies are expected to collide with the world.

This patch appears to be the minimum required change to fix the problem however it's a bit ugly: I have to set a reference to the MeshCollider in MeshData, which otherwise consists exclusively of readonly members. A proper fix would require modifying CreateSurfaceObject() but that is a bit more of an extensive modification and I think something along the line of my approach is simpler.