### PR TITLE
bugfix: the condition did not create a WorldAnchor component

### DIFF
--- a/Assets/HoloToolkit/Sharing/Tests/Scripts/ImportExportAnchorManager.cs
+++ b/Assets/HoloToolkit/Sharing/Tests/Scripts/ImportExportAnchorManager.cs
@@ -531,7 +531,7 @@ namespace HoloToolkit.Sharing.Tests
         /// </summary>
         private void CreateAnchorLocally()
         {
-            var anchor = GetComponent<WorldAnchor>() ?? gameObject.AddComponent<WorldAnchor>();
+            var anchor = GetComponent<WorldAnchor>() ? GetComponent<WorldAnchor>() : gameObject.AddComponent<WorldAnchor>();
 
             if (anchor.isLocated)
             {


### PR DESCRIPTION
The previous condition did not add the WolrdAnchor component to the gameobject, and raised an exception: MissingComponentException: There is no 'WorldAnchor' attached to the "HologramCollection" game object, but a script is trying to access it.