### PR TITLE
Editor update to 5.5.2f1

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -85,6 +85,7 @@ PlayerSettings:
   xboxEnableFitness: 0
   visibleInBackground: 0
   allowFullscreenSwitch: 1
+  graphicsJobMode: 0
   macFullscreenMode: 2
   d3d9FullscreenMode: 1
   d3d11FullscreenMode: 1

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 5.5.1f1
+m_EditorVersion: 5.5.2f1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This is effectively part of the existing HoloToolkit, but this is the repository that will contain all Unity specific components.
 The HoloToolkit is a collection of scripts and components intended to accelerate development of holographic applications targeting Windows Holographic.
 
-**Current Unity Editor Project Version: 5.5.1f1**
+**Required Unity Editor Version: 5.5.2f1**
 
 HoloToolkit contains the following feature areas:
 


### PR DESCRIPTION
Resolves https://github.com/Microsoft/HoloToolkit-Unity/issues/489

[See all the changes here](https://unity3d.com/unity/whats-new/unity-5.5.2)

HoloLens Specific fixes and changes:
> - (860775) - HoloLens: Fixed a crash that occurs on device when downloading files with WWW.
> - (847798) - Mono: Correct an invalid C# compiler error with generic types in compiler generated code (like lambdas and enumerators). The error from the C# compiler often includes this text: "There is no boxing or type parameter conversion from..."
> - (none) - Android/Metro: Fixed the issues preventing the Application.Unload API from functioning correctly.
> - (none ) - Scripting: Added the following non-allocating accessors to Mesh. These accessors write into a user-specified List. The accessors are GetBindposes, GetBoneWeights, GetColors, GetIndices, GetNormals, GetTangents, GetTriangles, and GetVertices.
> - (865507) - Audio: Fixed a WACK certification failure in UWP player builds using the Microsoft HRTF audio spatializer.
> - (824020) - Editor: Fixed a crash for D3D platforms if shader compilation did not return any compiled shader data ie, a shader contained #error pre-processor directive.
> - (814290) - Virtual Reality: Fixed inconsistency in game view between Singlepass Stereo and Multi Pass when using Split Stereo Diplay.
> - (830612) - Virtual Reality: Fixed incorrect culling in Split Stereo Display.
> - (832185) - Virtual Reality: Fixed incorrect eye view in Split Stereo Display.
> - (832283) - Virtual Reality: Fixed incorrect viewport bounds in Singlepass Stereo.
> - (850327, 851586) - HoloLens: Fixed an issue with InputField automatically getting activated for text entry as soon as you gaze at it.
> - (none) - HoloLens: Prevented a potential memory stomps in very rare repro cases when resuming from suspend.
> - (859819) - Graphics: DrawProcedural draws geometry only in the left eye when Single Pass is enabled.
> - (858579) - Windows Store: Fixed the folder Structure missing from Assembly-CSharp.csproj.
> - (855595) - Windows Store: Fixed player pref corruption on power loss.
> - Windows Store: introduced the ability to select which Universal Windows Platform SDK Unity should target when building the application.