### PR TITLE
Added possibility to lock the objects rotation while dragging it

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Interactions/HandDraggable.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Interactions/HandDraggable.cs
@@ -31,18 +31,16 @@ namespace HoloToolkit.Unity.InputModule
 
         [Tooltip("Scale by which hand movement in z is multipled to move the dragged object.")]
         public float DistanceScale = 2f;
+        
+        public enum RotationModeEnum
+        {
+            Default,
+            LockObjectRotation,
+            OrientTowardUser,
+            KeepUpright
+        }
 
-        [Header("Rotation Handling (only select one!)")]
-        [Tooltip("Should the object be kept upright as it is being dragged?")]
-        public bool IsKeepUpright = false;
-
-        [Tooltip("Should the object be oriented towards the user as it is being dragged?")]
-        public bool IsOrientTowardsUser = true;
-
-        [Tooltip("Should the rotation of the object be locked?")]
-        public bool LockRotation = false;
-
-        [Space(10)]
+        public RotationModeEnum RotationMode = RotationModeEnum.Default;
 
         public bool IsDraggingEnabled = true;
 
@@ -200,16 +198,20 @@ namespace HoloToolkit.Unity.InputModule
 
             draggingPosition = pivotPosition + (targetDirection * targetDistance);
 
-            if (IsOrientTowardsUser)
+            if (RotationMode == RotationModeEnum.OrientTowardUser)
             {
                 draggingRotation = Quaternion.LookRotation(HostTransform.position - pivotPosition);
             }
-            else if (IsKeepUpright)
+            else if (RotationMode == RotationModeEnum.KeepUpright)
             {
                 Quaternion upRotation = Quaternion.FromToRotation(HostTransform.up, Vector3.up);
-                draggingRotation = upRotation * HostTransform.rotation; ;
+                draggingRotation = upRotation * HostTransform.rotation;
             }
-            else if (!IsRotationLocked)
+            else if (RotationMode == RotationModeEnum.LockObjectRotation)
+            {
+                draggingRotation = HostTransform.rotation;
+            }
+            else
             {
                 Vector3 objForward = mainCamera.transform.TransformDirection(objRefForward); // in world space
                 Vector3 objUp = mainCamera.transform.TransformDirection(objRefUp);   // in world space

--- a/Assets/HoloToolkit/Input/Scripts/Interactions/HandDraggable.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Interactions/HandDraggable.cs
@@ -37,7 +37,7 @@ namespace HoloToolkit.Unity.InputModule
             Default,
             LockObjectRotation,
             OrientTowardUser,
-            KeepUpright
+            OrientTowardUserAndKeepUpright
         }
 
         public RotationModeEnum RotationMode = RotationModeEnum.Default;
@@ -198,20 +198,15 @@ namespace HoloToolkit.Unity.InputModule
 
             draggingPosition = pivotPosition + (targetDirection * targetDistance);
 
-            if (RotationMode == RotationModeEnum.OrientTowardUser)
+            if (RotationMode == RotationModeEnum.OrientTowardUser || RotationMode == RotationModeEnum.OrientTowardUserAndKeepUpright) 
             {
                 draggingRotation = Quaternion.LookRotation(HostTransform.position - pivotPosition);
-            }
-            else if (RotationMode == RotationModeEnum.KeepUpright)
-            {
-                Quaternion upRotation = Quaternion.FromToRotation(HostTransform.up, Vector3.up);
-                draggingRotation = upRotation * HostTransform.rotation;
             }
             else if (RotationMode == RotationModeEnum.LockObjectRotation)
             {
                 draggingRotation = HostTransform.rotation;
             }
-            else
+            else // RotationModeEnum.Default
             {
                 Vector3 objForward = mainCamera.transform.TransformDirection(objRefForward); // in world space
                 Vector3 objUp = mainCamera.transform.TransformDirection(objRefUp);   // in world space
@@ -222,6 +217,11 @@ namespace HoloToolkit.Unity.InputModule
             HostTransform.position = draggingPosition + mainCamera.transform.TransformDirection(objRefGrabPoint);
             // Apply Final Rotation
             HostTransform.rotation = draggingRotation;
+            if (RotationMode == RotationModeEnum.OrientTowardUserAndKeepUpright)		
+            {		
+                Quaternion upRotation = Quaternion.FromToRotation(HostTransform.up, Vector3.up);		
+                HostTransform.rotation = upRotation * HostTransform.rotation;		
+            }
         }
 
         /// <summary>

--- a/Assets/HoloToolkit/Input/Scripts/Interactions/HandDraggable.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Interactions/HandDraggable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using UnityEngine;
@@ -32,11 +32,17 @@ namespace HoloToolkit.Unity.InputModule
         [Tooltip("Scale by which hand movement in z is multipled to move the dragged object.")]
         public float DistanceScale = 2f;
 
+        [Header("Rotation Handling (only select one!)")]
         [Tooltip("Should the object be kept upright as it is being dragged?")]
         public bool IsKeepUpright = false;
 
         [Tooltip("Should the object be oriented towards the user as it is being dragged?")]
         public bool IsOrientTowardsUser = true;
+
+        [Tooltip("Should the rotation of the object be locked?")]
+        public bool LockRotation = false;
+
+        [Space(10)]
 
         public bool IsDraggingEnabled = true;
 
@@ -198,7 +204,12 @@ namespace HoloToolkit.Unity.InputModule
             {
                 draggingRotation = Quaternion.LookRotation(HostTransform.position - pivotPosition);
             }
-            else
+            else if (IsKeepUpright)
+            {
+                Quaternion upRotation = Quaternion.FromToRotation(HostTransform.up, Vector3.up);
+                draggingRotation = upRotation * HostTransform.rotation; ;
+            }
+            else if (!IsRotationLocked)
             {
                 Vector3 objForward = mainCamera.transform.TransformDirection(objRefForward); // in world space
                 Vector3 objUp = mainCamera.transform.TransformDirection(objRefUp);   // in world space
@@ -207,13 +218,8 @@ namespace HoloToolkit.Unity.InputModule
 
             // Apply Final Position
             HostTransform.position = draggingPosition + mainCamera.transform.TransformDirection(objRefGrabPoint);
+            // Apply Final Rotation
             HostTransform.rotation = draggingRotation;
-
-            if (IsKeepUpright)
-            {
-                Quaternion upRotation = Quaternion.FromToRotation(HostTransform.up, Vector3.up);
-                HostTransform.rotation = upRotation * HostTransform.rotation;
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
When u drag a object via HandDraggable and move your head the rotation of the object changes.
At least in my case I don't want that, it somehow feels unnatural, so I implemented a public flag to prevent this behaivour (lock the rotation of the object).
Also I added a Header and Space for grouping the different rotation modes in the inspector (probably change the text there a bit?)
And I grouped the handling of the rotation modes (upright, towards user, lock orientation)  into an if-else if-else if construct. If nothing applies (when IsRotationLocked == true) the rotation of the object isn't changed at all (my desired behaivour).

Any opinions?