### PR TITLE
Make Spatial Mapping use unscaledTime

### DIFF
--- a/Assets/HoloToolkit/SpatialMapping/Scripts/SpatialMappingManager.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/SpatialMappingManager.cs
@@ -212,7 +212,7 @@ namespace HoloToolkit.Unity.SpatialMapping
             if (!IsObserverRunning())
             {
                 surfaceObserver.StartObserving();
-                StartTime = Time.time;
+                StartTime = Time.unscaledTime;
             }
         }
 

--- a/Assets/HoloToolkit/SpatialMapping/Scripts/SpatialMappingObserver.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/SpatialMappingObserver.cs
@@ -150,10 +150,10 @@ namespace HoloToolkit.Unity.SpatialMapping
                         ReclaimSurface(newSurface);
                     }
                 }
-                else if ((Time.time - updateTime) >= TimeBetweenUpdates)
+                else if ((Time.unscaledTime - updateTime) >= TimeBetweenUpdates)
                 {
                     observer.Update(SurfaceObserver_OnSurfaceChanged);
-                    updateTime = Time.time;
+                    updateTime = Time.unscaledTime;
                 }
             }
         }

--- a/Assets/HoloToolkit/SpatialMapping/Tests/Scripts/SpatialProcessingTest.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Tests/Scripts/SpatialProcessingTest.cs
@@ -48,7 +48,7 @@ namespace HoloToolkit.Unity.SpatialMapping.Tests
             {
                 // Check to see if enough scanning time has passed
                 // since starting the observer.
-                if ((Time.time - SpatialMappingManager.Instance.StartTime) < scanTime)
+                if ((Time.unscaledTime - SpatialMappingManager.Instance.StartTime) < scanTime)
                 {
                     // If we have a limited scanning time, then we should wait until
                     // enough time has passed before processing the mesh.


### PR DESCRIPTION
Related to https://github.com/Microsoft/HoloToolkit-Unity/issues/79 - when physics in Unity are paused using timeScale = 0.0f (which is quite a common use case), the spatial mapping stops too, which is undesirable in almost all circumstances.

The common use case is actually the opposite: the game is usually paused, while the HoloLens is allowed to gather spatial mapping data.

The change to unscaledTime allows Spatial Mapping to continue while the physics are
paused.