### PR TITLE
Using UnityObjectToClipPos according to performance recommendations

### DIFF
--- a/Assets/HoloToolkit-Tests/Input/Shaders/button_unlit_shader.shader
+++ b/Assets/HoloToolkit-Tests/Input/Shaders/button_unlit_shader.shader
@@ -52,7 +52,7 @@
 			struct v2f
 			{
 				float4 pos : SV_POSITION;
-				fixed4 uv : TEXCOORD0;
+				fixed3 uv : TEXCOORD0;
 				fixed3 localNormal : TEXCOORD1;
 				fixed3 viewDir : TEXCOORD2;
 				fixed3 halfVec : TEXCOORD3;
@@ -63,7 +63,7 @@
 			{
 				v2f o;
 
-				o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+				o.pos = UnityObjectToClipPos(v.vertex);
 				o.uv.xy = v.texcoord;
 				o.localNormal = normalize(v.normal);
 				o.viewDir = normalize(ObjSpaceViewDir(v.vertex));

--- a/Assets/HoloToolkit/Input/Shaders/Cursor.shader
+++ b/Assets/HoloToolkit/Input/Shaders/Cursor.shader
@@ -37,7 +37,7 @@
 				UNITY_SETUP_INSTANCE_ID(v);
 
 				v2f o;
-				o.vertex = mul(UNITY_MATRIX_MVP, v.vertex);
+				o.vertex = UnityObjectToClipPos(v.vertex);
 
 				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
 				return o;

--- a/Assets/HoloToolkit/Input/Shaders/CursorShader.shader
+++ b/Assets/HoloToolkit/Input/Shaders/CursorShader.shader
@@ -71,7 +71,7 @@ Shader "HoloToolkit/Cursor"
 				UNITY_SETUP_INSTANCE_ID(IN);
 
 				v2f OUT;
-				OUT.vertex = mul(UNITY_MATRIX_MVP, IN.vertex);
+				OUT.vertex = UnityObjectToClipPos(IN.vertex);
 				OUT.texcoord = IN.texcoord;
 #ifdef UNITY_HALF_TEXEL_OFFSET
 				OUT.vertex.xy += (_ScreenParams.zw-1.0)*float2(-1,1);

--- a/Assets/HoloToolkit/Input/Shaders/EditorHands.shader
+++ b/Assets/HoloToolkit/Input/Shaders/EditorHands.shader
@@ -67,7 +67,7 @@
             {
                 UNITY_SETUP_INSTANCE_ID(IN);
                 v2f OUT;
-                OUT.vertex = mul(UNITY_MATRIX_MVP, IN.vertex);
+                OUT.vertex = UnityObjectToClipPos(IN.vertex);
                 OUT.texcoord = IN.texcoord;
                 #ifdef UNITY_HALF_TEXEL_OFFSET
                 OUT.vertex.xy += (_ScreenParams.zw-1.0)*float2(-1,1);

--- a/Assets/HoloToolkit/Input/Shaders/SpecularHighlight.shader
+++ b/Assets/HoloToolkit/Input/Shaders/SpecularHighlight.shader
@@ -92,7 +92,7 @@ Shader "HoloToolkit/SpecularHighlight"
             v2f vert(appdata_t v)
             {
                 v2f o;
-                o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+                o.pos = UnityObjectToClipPos(v.vertex);
                 o.uv = v.texcoord;
 
                 //Setup vectors for light probe contribution, w = 1.

--- a/Assets/HoloToolkit/SpatialMapping/Shaders/Occlusion.shader
+++ b/Assets/HoloToolkit/SpatialMapping/Shaders/Occlusion.shader
@@ -40,7 +40,7 @@ Shader "HoloToolkit/Occlusion"
             {
                 UNITY_SETUP_INSTANCE_ID(v);
                 v2f o;
-                o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+                o.pos = UnityObjectToClipPos(v.vertex);
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
                 return o;
             }

--- a/Assets/HoloToolkit/SpatialMapping/Shaders/SpatialMappingTap.shader
+++ b/Assets/HoloToolkit/SpatialMapping/Shaders/SpatialMappingTap.shader
@@ -60,7 +60,7 @@ Shader "Spatial Mapping/Spatial Mappping Tap"
 			{
 				v2g o;
 
-				o.viewPos = mul(UNITY_MATRIX_MVP, v.vertex);
+				o.viewPos = UnityObjectToClipPos(v.vertex);
 
 				float4 worldPos = mul(unity_ObjectToWorld, v.vertex);
 				half distToCenter = distance(_Center, worldPos.xyz);		

--- a/Assets/HoloToolkit/SpatialMapping/Shaders/Wireframe.shader
+++ b/Assets/HoloToolkit/SpatialMapping/Shaders/Wireframe.shader
@@ -45,7 +45,7 @@ Shader "HoloToolkit/Wireframe"
             {
                 UNITY_SETUP_INSTANCE_ID(v);
                 v2g o;
-                o.viewPos = mul(UNITY_MATRIX_MVP, v.vertex);
+                o.viewPos = UnityObjectToClipPos(v.vertex);
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
                 return o;
             }

--- a/Assets/HoloToolkit/SpatialUnderstanding/Materials/SpatialMappingSurface.shader
+++ b/Assets/HoloToolkit/SpatialUnderstanding/Materials/SpatialMappingSurface.shader
@@ -44,7 +44,7 @@ Shader "HoloToolkit/SpatialUnderstanding/Mapping"
             {
                 UNITY_SETUP_INSTANCE_ID(v);
                 v2g o;
-                o.viewPos = mul(UNITY_MATRIX_MVP, v.vertex);
+                o.viewPos = UnityObjectToClipPos(v.vertex);
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
                 return o;
             }

--- a/Assets/HoloToolkit/SpatialUnderstanding/Materials/SpatialUnderstandingSurface.shader
+++ b/Assets/HoloToolkit/SpatialUnderstanding/Materials/SpatialUnderstandingSurface.shader
@@ -45,7 +45,7 @@ Shader "HoloToolkit/SpatialUnderstanding/Understanding"
            {
                v2g o;
                UNITY_SETUP_INSTANCE_ID(v);
-               o.viewPos = mul(UNITY_MATRIX_MVP, v.vertex);
+               o.viewPos = UnityObjectToClipPos(v.vertex);
                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
                return o;
            }

--- a/Assets/HoloToolkit/UI/Shaders/3DTextShader.shader
+++ b/Assets/HoloToolkit/UI/Shaders/3DTextShader.shader
@@ -71,7 +71,7 @@
                 v2f vert (appdata_t v)
                 {
                     v2f o;
-                    o.vertex = mul(UNITY_MATRIX_MVP, v.vertex);
+                    o.vertex = UnityObjectToClipPos(v.vertex);
                     o.texcoord = TRANSFORM_TEX(v.texcoord, _MainTex);
                     o.color = v.color;
                     #ifdef UNITY_HALF_TEXEL_OFFSET

--- a/Assets/HoloToolkit/Utilities/Shaders/HoloToolkitCommon.cginc
+++ b/Assets/HoloToolkit/Utilities/Shaders/HoloToolkitCommon.cginc
@@ -1,3 +1,5 @@
+#include "UnityCG.cginc"
+
 #ifndef HOLOTOOLKIT_COMMON
 #define HOLOTOOLKIT_COMMON
 
@@ -7,7 +9,7 @@ float4 _NearPlaneFadeDistance;
 // Could instead be done non-linear in projected space for speed
 inline float ComputeNearPlaneFadeLinear(float4 vertex)
 {
-    float distToCamera = -(mul(UNITY_MATRIX_MV, vertex).z);
+    float distToCamera = -(UnityObjectToViewPos(vertex).z);
     return saturate(mad(distToCamera, _NearPlaneFadeDistance.y, _NearPlaneFadeDistance.x));
 }
 

--- a/Assets/HoloToolkit/Utilities/Shaders/UnlitConfigurable.cginc
+++ b/Assets/HoloToolkit/Utilities/Shaders/UnlitConfigurable.cginc
@@ -35,7 +35,7 @@ v2f vert(appdata_t v)
 {
     UNITY_SETUP_INSTANCE_ID(v);
     v2f o;
-    o.vertex = mul(UNITY_MATRIX_MVP, v.vertex);
+    o.vertex = UnityObjectToClipPos(v.vertex);
 
     #if _USEMAINTEX_ON
         o.texcoord = TRANSFORM_TEX(v.texcoord, _MainTex);

--- a/Assets/HoloToolkit/Utilities/Shaders/UnlitNoDepthTest.shader
+++ b/Assets/HoloToolkit/Utilities/Shaders/UnlitNoDepthTest.shader
@@ -40,7 +40,7 @@
 			{
 				UNITY_SETUP_INSTANCE_ID(v);
 				v2f o;
-				o.vertex = mul(UNITY_MATRIX_MVP, v.vertex);
+				o.vertex = UnityObjectToClipPos(v.vertex);
 				o.uv = v.uv;
 				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
 				return o;

--- a/Assets/HoloToolkit/Utilities/Shaders/VertexLitConfigurable.cginc
+++ b/Assets/HoloToolkit/Utilities/Shaders/VertexLitConfigurable.cginc
@@ -60,7 +60,7 @@ v2f_surf vert(appdata_t v)
     v2f_surf o;
     UNITY_INITIALIZE_OUTPUT(v2f_surf, o);
 
-    o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+    o.pos = UnityObjectToClipPos(v.vertex);
 
     #if _USEMAINTEX_ON || _USEEMISSIONTEX_ON
         o.pack0.xy = TRANSFORM_TEX(v.texcoord, _MainTex);

--- a/Assets/HoloToolkit/Utilities/Shaders/WindowOcclusion.shader
+++ b/Assets/HoloToolkit/Utilities/Shaders/WindowOcclusion.shader
@@ -39,7 +39,7 @@ Shader "HoloToolkit/WindowOcclusion"
             {
                 UNITY_SETUP_INSTANCE_ID(v);
                 v2f o;
-                o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+                o.pos = UnityObjectToClipPos(v.vertex);
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
                 return o;
             }


### PR DESCRIPTION
`UnityObjectToClipPos` is supposed to be faster than multiplying by `UNITY_MATRIX_MVP` when using SinglePassStereo and/or when using concatenated matrices. The same applies to `UnityObjectToViewPos` and `UNITY_MATRIX_MV`.  

The Unity team has mentioned this in a couple talks recently, and Unity 5.6 has starts providing a performance warning when importing shaders that use UNITY_MATRIX_MVP, etc, so I figured its probably worth addressing.