### PR TITLE
Greatly speed up RemoveSurfaceVertices

### DIFF
--- a/Assets/HoloToolkit/SpatialMapping/Scripts/SpatialProcessing/RemoveSurfaceVertices.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/SpatialProcessing/RemoveSurfaceVertices.cs
@@ -149,7 +149,7 @@ namespace HoloToolkit.Unity.SpatialMapping
 
                     // Remove vertices from any mesh that intersects with the bounds.
                     Vector3[] verts = mesh.vertices;
-                    List<int> vertsToRemove = new List<int>();
+                    HashSet<int> vertsToRemove = new HashSet<int>();
 
                     // Find which mesh vertices are within the bounds.
                     for (int i = 0; i < verts.Length; ++i)


### PR DESCRIPTION
Changing from List to HashSet greatly improves the speed of .contains(), which allows RemoveSurfaceVertices to complete in at most 1 or 2 seconds as opposed to 10+ previously.