### PR TITLE
bugfix for Cursor: TargetedCursorModifier should've been nulled

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Cursor/Cursor.cs
@@ -285,6 +285,7 @@ namespace HoloToolkit.Unity.InputModule
             if (TargetedObject == null)
             {
                 this.TargetedObject = null;
+                this.TargetedCursorModifier = null;
                 targetPosition = gazeManager.GazeOrigin + gazeManager.GazeNormal * DefaultCursorDistance;
                 targetRotation = lookForward.magnitude > 0 ? Quaternion.LookRotation(lookForward, Vector3.up) : transform.rotation;
             }


### PR DESCRIPTION
TargetedCursorModifier is dependent on TargetedObject and therefore should be cleared out whenever TargetedObject is cleared out

Resolves #584 