### PR TITLE
Add smoothing to translation and rotation for HandDraggable script

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Interactions/HandDraggable.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Interactions/HandDraggable.cs
@@ -42,6 +42,14 @@ namespace HoloToolkit.Unity.InputModule
 
         public RotationModeEnum RotationMode = RotationModeEnum.Default;
 
+        [Tooltip("Controls the speed at which the object will interpolate toward the desired position")]
+        [Range(0.01f, 1.0f)]
+        public float PositionLerpSpeed = 0.2f;
+
+        [Tooltip("Controls the speed at which the object will interpolate toward the desired rotation")]
+        [Range(0.01f, 1.0f)]
+        public float RotationLerpSpeed = 0.2f;
+
         public bool IsDraggingEnabled = true;
 
         private Camera mainCamera;
@@ -214,9 +222,10 @@ namespace HoloToolkit.Unity.InputModule
             }
 
             // Apply Final Position
-            HostTransform.position = draggingPosition + mainCamera.transform.TransformDirection(objRefGrabPoint);
+            HostTransform.position = Vector3.Lerp(HostTransform.position, draggingPosition + mainCamera.transform.TransformDirection(objRefGrabPoint), PositionLerpSpeed);
             // Apply Final Rotation
-            HostTransform.rotation = draggingRotation;
+            HostTransform.rotation = Quaternion.Lerp(HostTransform.rotation, draggingRotation, RotationLerpSpeed);
+
             if (RotationMode == RotationModeEnum.OrientTowardUserAndKeepUpright)		
             {		
                 Quaternion upRotation = Quaternion.FromToRotation(HostTransform.up, Vector3.up);		


### PR DESCRIPTION
[This issue ](https://forums.hololens.com/discussion/7036/moving-object-very-slow-juddering) has come up as a question once or twice in the forums, and I had a fix for this in my own project that I figured I could contribute back to the main repository.

I didn't add specific code to disable this, but setting the speed values to 1.0 will effectively give you the same behavior as before. The default values are just what felt good to me, but I'm open to tweaking the defaults if people prefer things more responsive, or smoother.