### PR TITLE
Added confirmation dialogues to EnforceEditorSettings

### DIFF
--- a/Assets/HoloToolkit/Utilities/Scripts/Editor/EnforceEditorSettings.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Editor/EnforceEditorSettings.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-
 using UnityEditor;
 
 namespace HoloToolKit.Unity
@@ -11,23 +10,68 @@ namespace HoloToolKit.Unity
     [InitializeOnLoad]
     public class EnforceEditorSettings
     {
+        private const string _assemblyReloadTimestampKey = "HoloToolkit_Editor_LastAssemblyReload";
+
         static EnforceEditorSettings()
         {
             #region Editor Settings
 
-            if (EditorSettings.serializationMode != SerializationMode.ForceText)
-            {
-                EditorSettings.serializationMode = SerializationMode.ForceText;
-                UnityEngine.Debug.Log("Setting Force Text Serialization");
-            }
+            if (TrueOnce()) {
+                if (EditorSettings.serializationMode != SerializationMode.ForceText)
+                {
+                    if (EditorUtility.DisplayDialog( 
+                            "Force Text Asset Serialization?", 
+                            "HoloToolkit is easier to maintain if the asset serialization mode for this project is set to \"Force Text\". Would you like to make this change?", 
+                            "Force Text Serialization", 
+                            "Later")) {
+                        EditorSettings.serializationMode = SerializationMode.ForceText;
+                        UnityEngine.Debug.Log("Setting Force Text Serialization");
+                    }
+                }
 
-            if (!EditorSettings.externalVersionControl.Equals("Visible Meta Files"))
-            {
-                EditorSettings.externalVersionControl = "Visible Meta Files";
-                UnityEngine.Debug.Log("Updated external version control mode: " + EditorSettings.externalVersionControl);
+                if (!EditorSettings.externalVersionControl.Equals("Visible Meta Files"))
+                {
+                    if (EditorUtility.DisplayDialog( 
+                        "Make Meta Files Visible?", 
+                        "HoloToolkit would like to make meta files visible so they can be more easily handled with common version control systems. Would you like to make this change?", 
+                        "Enable Visible Meta Files", 
+                        "Later")) {
+                        EditorSettings.externalVersionControl = "Visible Meta Files";
+                        UnityEngine.Debug.Log("Updated external version control mode: " + EditorSettings.externalVersionControl);
+                    }
+                }
             }
 
             #endregion
+        }
+
+        /// <summary>
+        /// Returns true the first time it is called within this editor session, and
+        /// false for all subsequent calls.
+        /// </summary>
+        /// <remarks>
+        /// The Unity Editor does not provide a callback for when a project is opened.
+        /// InitializeOnLoad is triggered for all assembly reloads, including entering
+        /// and exiting PlayMode, and whenever a script is modified and recompiled.
+        ///
+        /// To ensure execution only when opening a project in a new instance of the editor,
+        /// store a timestamp in the editor key-value store whenever this function is called. 
+        /// The stored timestamp is then compared with the true start time of this editor
+        /// instance.
+        /// </remarks>
+        private static bool TrueOnce () 
+        {
+            // Determine the last known launch date of the editor by loading it from the PlayerPrefs cache.
+            System.DateTime lastLaunchDate = System.DateTime.UtcNow;
+            System.DateTime.TryParse( EditorPrefs.GetString(_assemblyReloadTimestampKey), out lastLaunchDate );
+
+            // Determine the launch date for this editor session using the current time, and the time since startup.
+            System.DateTime thisLaunchDate = System.DateTime.UtcNow.AddSeconds(-EditorApplication.timeSinceStartup);
+            EditorPrefs.SetString(_assemblyReloadTimestampKey, thisLaunchDate.ToString());
+
+            // If the current session was launched later than the last known session start date, then this must be 
+            // a new session, and we can display the first-time prompt.
+            return (thisLaunchDate - lastLaunchDate).Seconds > 0;
         }
     }
 }

--- a/Assets/HoloToolkit/Utilities/Scripts/Editor/EnforceEditorSettings.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Editor/EnforceEditorSettings.cs
@@ -16,32 +16,37 @@ namespace HoloToolkit.Unity
         {
             #region Editor Settings
 
-            if (TrueOnce()) {
-                if (EditorSettings.serializationMode != SerializationMode.ForceText)
-                {
-                    if (EditorUtility.DisplayDialog( 
-                            "Force Text Asset Serialization?", 
-                            "HoloToolkit is easier to maintain if the asset serialization mode for this project is set to \"Force Text\". Would you like to make this change?", 
-                            "Force Text Serialization", 
-                            "Later")) {
-                        EditorSettings.serializationMode = SerializationMode.ForceText;
-                        UnityEngine.Debug.Log("Setting Force Text Serialization");
-                    }
-                }
+            if (!IsNewEditorSession())
+            {
+                return;
+            }
 
-                if (!EditorSettings.externalVersionControl.Equals("Visible Meta Files"))
+            if (EditorSettings.serializationMode != SerializationMode.ForceText)
+            {
+                if (EditorUtility.DisplayDialog( 
+                        "Force Text Asset Serialization?", 
+                        "HoloToolkit is easier to maintain if the asset serialization mode for this project is set to \"Force Text\". Would you like to make this change?", 
+                        "Force Text Serialization", 
+                        "Later")) 
                 {
-                    if (EditorUtility.DisplayDialog( 
-                        "Make Meta Files Visible?", 
-                        "HoloToolkit would like to make meta files visible so they can be more easily handled with common version control systems. Would you like to make this change?", 
-                        "Enable Visible Meta Files", 
-                        "Later")) {
-                        EditorSettings.externalVersionControl = "Visible Meta Files";
-                        UnityEngine.Debug.Log("Updated external version control mode: " + EditorSettings.externalVersionControl);
-                    }
+                    EditorSettings.serializationMode = SerializationMode.ForceText;
+                    UnityEngine.Debug.Log("Setting Force Text Serialization");
                 }
             }
 
+            if (!EditorSettings.externalVersionControl.Equals("Visible Meta Files"))
+            {
+                if (EditorUtility.DisplayDialog( 
+                    "Make Meta Files Visible?", 
+                    "HoloToolkit would like to make meta files visible so they can be more easily handled with common version control systems. Would you like to make this change?", 
+                    "Enable Visible Meta Files", 
+                    "Later"))
+                {
+                    EditorSettings.externalVersionControl = "Visible Meta Files";
+                    UnityEngine.Debug.Log("Updated external version control mode: " + EditorSettings.externalVersionControl);
+                }
+            }
+            
             #endregion
         }
 
@@ -59,11 +64,11 @@ namespace HoloToolkit.Unity
         /// The stored timestamp is then compared with the true start time of this editor
         /// instance.
         /// </remarks>
-        private static bool TrueOnce () 
+        private static bool IsNewEditorSession () 
         {
             // Determine the last known launch date of the editor by loading it from the PlayerPrefs cache.
             System.DateTime lastLaunchDate = System.DateTime.UtcNow;
-            System.DateTime.TryParse( EditorPrefs.GetString(_assemblyReloadTimestampKey), out lastLaunchDate );
+            System.DateTime.TryParse(EditorPrefs.GetString(_assemblyReloadTimestampKey), out lastLaunchDate);
 
             // Determine the launch date for this editor session using the current time, and the time since startup.
             System.DateTime thisLaunchDate = System.DateTime.UtcNow.AddSeconds(-EditorApplication.timeSinceStartup);

--- a/Assets/HoloToolkit/Utilities/Scripts/Editor/EnforceEditorSettings.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Editor/EnforceEditorSettings.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 using UnityEditor;
 
-namespace HoloToolKit.Unity
+namespace HoloToolkit.Unity
 {
     /// <summary>
     /// Sets Force Text Serialization and visible meta files in all projects that use the HoloToolkit.


### PR DESCRIPTION
The existing version does not feature a prompt, and modifies the
project configuration without warning. Users with complex or unique
project setups may encounter issues.

Users will now be prompted to change their project settings when
importing the HoloToolkit, or opening a project with the toolkit
already included, to better support external VCS and project
maintainability.

___

Whether or not this pull request is worth including is up for debate. It adds a new pop-up every time the editor is launched until project settings are modified, and is a good deal more involved than the previous implementation.

\- Requires user attention when first importing a project
\- Requires a field in the EditorPrefs store to save pop-up state.
\+ Allows users to delay the changes to their project settings until they can back up, or test the project.
