### PR TITLE
Fixed issue with GazeManager not hitting the closest UI element when raycasting.

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
@@ -225,7 +225,7 @@ namespace HoloToolkit.Unity.InputModule
             // Graphics raycast
             raycastResultList.Clear();
             EventSystem.current.RaycastAll(UnityUIPointerEvent, raycastResultList);
-            RaycastResult uiRaycastResult = FindClosestRaycastInLayermasks(raycastResultList, RaycastLayerMasks);
+            RaycastResult uiRaycastResult = FindClosestRaycastHitInLayermasks(raycastResultList, RaycastLayerMasks);
             UnityUIPointerEvent.pointerCurrentRaycast = uiRaycastResult;
 
             // If we have a raycast result, check if we need to overwrite the 3D raycast info
@@ -292,7 +292,7 @@ namespace HoloToolkit.Unity.InputModule
         /// <param name="candidates">List of RaycastResults from a Unity UI raycast</param>
         /// <param name="layerMaskList">List of layers to support</param>
         /// <returns>RaycastResult if hit, or an empty RaycastResult if nothing was hit</returns>
-        private RaycastResult FindClosestRaycastInLayermasks(List<RaycastResult> candidates, LayerMask[] layerMaskList)
+        private RaycastResult FindClosestRaycastHitInLayermasks(List<RaycastResult> candidates, LayerMask[] layerMaskList)
         {
             int combinedLayerMask = 0;
             for (int i = 0; i < layerMaskList.Length; i++)

--- a/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
@@ -300,19 +300,22 @@ namespace HoloToolkit.Unity.InputModule
                 combinedLayerMask = combinedLayerMask | layerMaskList[i].value;
             }
 
+            RaycastResult? minHit = null;
             for (var i = 0; i < candidates.Count; ++i)
             {
                 if (candidates[i].gameObject == null || !IsLayerInLayerMask(candidates[i].gameObject.layer, combinedLayerMask))
                 {
                     continue;
                 }
-
-                return candidates[i];
+                if (minHit == null || candidates[i].distance < minHit.Value.distance)
+                {
+                    minHit = candidates[i];
+                }
             }
 
-            return new RaycastResult();
+             return minHit ?? new RaycastResult();
         }
-
+        
         /// <summary>
         /// Look through the layerMaskList and find the index in that list for which the supplied layer is part of
         /// </summary>

--- a/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
@@ -225,7 +225,7 @@ namespace HoloToolkit.Unity.InputModule
             // Graphics raycast
             raycastResultList.Clear();
             EventSystem.current.RaycastAll(UnityUIPointerEvent, raycastResultList);
-            RaycastResult uiRaycastResult = FindFirstRaycastInLayermasks(raycastResultList, RaycastLayerMasks);
+            RaycastResult uiRaycastResult = FindClosestRaycastInLayermasks(raycastResultList, RaycastLayerMasks);
             UnityUIPointerEvent.pointerCurrentRaycast = uiRaycastResult;
 
             // If we have a raycast result, check if we need to overwrite the 3D raycast info
@@ -287,12 +287,12 @@ namespace HoloToolkit.Unity.InputModule
         #region Helpers
 
         /// <summary>
-        /// Find the first (closest) raycast in the list of RaycastResults that is also included in the LayerMask list.  
+        /// Find the closest raycast hit in the list of RaycastResults that is also included in the LayerMask list.  
         /// </summary>
         /// <param name="candidates">List of RaycastResults from a Unity UI raycast</param>
         /// <param name="layerMaskList">List of layers to support</param>
         /// <returns>RaycastResult if hit, or an empty RaycastResult if nothing was hit</returns>
-        private RaycastResult FindFirstRaycastInLayermasks(List<RaycastResult> candidates, LayerMask[] layerMaskList)
+        private RaycastResult FindClosestRaycastInLayermasks(List<RaycastResult> candidates, LayerMask[] layerMaskList)
         {
             int combinedLayerMask = 0;
             for (int i = 0; i < layerMaskList.Length; i++)


### PR DESCRIPTION
 Now the closest hit is picked instead of the first one.

This was an issue when multiple UI canvases was on top of each other. The Raycast result was not ordered, and the FindFirstRaycastInLayermasks returned the first hit in the list, not the closest hit. 
Now the code checks the distance of the hist to return the closest one.