### PR TITLE
Namespace fixes

### DIFF
--- a/Assets/HoloToolkit/Build/Editor/HoloToolkitCommands.cs
+++ b/Assets/HoloToolkit/Build/Editor/HoloToolkitCommands.cs
@@ -3,18 +3,19 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 //
 
-using HoloToolkit.Unity;
-
-/// <summary>
-/// Implements functionality for building HoloLens applications
-/// </summary>
-public static class HoloToolkitCommands
+namespace HoloToolkit.Unity
 {
     /// <summary>
-    /// Do a build configured for the HoloLens, returns the error from BuildPipeline.BuildPlayer
+    /// Implements functionality for building HoloLens applications
     /// </summary>
-    public static bool BuildSLN()
+    public static class HoloToolkitCommands
     {
-        return BuildDeployTools.BuildSLN(BuildDeployPrefs.BuildDirectory, false);
+        /// <summary>
+        /// Do a build configured for the HoloLens, returns the error from BuildPipeline.BuildPlayer
+        /// </summary>
+        public static bool BuildSLN()
+        {
+            return BuildDeployTools.BuildSLN(BuildDeployPrefs.BuildDirectory, false);
+        }
     }
 }

--- a/Assets/HoloToolkit/CrossPlatform/Scripts/Reflection/ReflectionExtensions.cs
+++ b/Assets/HoloToolkit/CrossPlatform/Scripts/Reflection/ReflectionExtensions.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace HoloToolkit
+namespace HoloToolkit.Unity
 {
 #if UNITY_METRO && !UNITY_EDITOR
 

--- a/Assets/HoloToolkit/CrossPlatform/Scripts/Reflection/ReflectionExtensions.cs
+++ b/Assets/HoloToolkit/CrossPlatform/Scripts/Reflection/ReflectionExtensions.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace HoloToolkit.Unity
+namespace HoloToolkit
 {
 #if UNITY_METRO && !UNITY_EDITOR
 

--- a/Assets/HoloToolkit/CrossPlatform/Scripts/Reflection/TypeUtils.cs
+++ b/Assets/HoloToolkit/CrossPlatform/Scripts/Reflection/TypeUtils.cs
@@ -2,19 +2,18 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Text;
 
-public static class TypeUtils
+namespace HoloToolkit.Unity
 {
-    public static Type GetBaseType(this Type type)
+    public static class TypeUtils
     {
+        public static Type GetBaseType(this Type type)
+        {
 #if UNITY_METRO && !UNITY_EDITOR
-        return type.GetTypeInfo().BaseType;
+            return type.GetTypeInfo().BaseType;
 #else
-        return type.BaseType;
+            return type.BaseType;
 #endif
+        }
     }
 }

--- a/Assets/HoloToolkit/Input/Scripts/Editor/EditorHandsMaterialInspector.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Editor/EditorHandsMaterialInspector.cs
@@ -1,14 +1,17 @@
 ﻿using UnityEditor;
 
-public class EditorHandsMaterialInspector : ShaderGUI
+namespace HoloToolkit.Unity
 {
-    public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] properties)
+    public class EditorHandsMaterialInspector : ShaderGUI
     {
-        foreach (MaterialProperty materialProperty in properties)
+        public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] properties)
         {
-            if (materialProperty.flags != MaterialProperty.PropFlags.PerRendererData)
+            foreach (MaterialProperty materialProperty in properties)
             {
-                materialEditor.ShaderProperty(materialProperty, materialProperty.displayName);
+                if (materialProperty.flags != MaterialProperty.PropFlags.PerRendererData)
+                {
+                    materialEditor.ShaderProperty(materialProperty, materialProperty.displayName);
+                }
             }
         }
     }

--- a/Assets/HoloToolkit/Utilities/Scripts/Editor/EnforceEditorSettings.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Editor/EnforceEditorSettings.cs
@@ -3,7 +3,7 @@
 
 using UnityEditor;
 
-namespace HoloToolKit.Unity
+namespace HoloToolkit.Unity
 {
     /// <summary>
     /// Sets Force Text Serialization and visible meta files in all projects that use the HoloToolkit.


### PR DESCRIPTION
Adds scripts to `HoloToolkit.Unity`, if no namespace declaired.
Simple typo fixes in existing namespaces.