### PR TITLE
use SwitchActiveBuildTarget(BuildTargetGroup targetGroup, BuildTarget…

### DIFF
--- a/Assets/HoloToolkit/Utilities/Scripts/Editor/ProjectSettingsWindow.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Editor/ProjectSettingsWindow.cs
@@ -205,7 +205,7 @@ namespace HoloToolkit.Unity
             // Apply individual settings
             if (Values[ProjectSetting.BuildWsaUwp])
             {
-                EditorUserBuildSettings.SwitchActiveBuildTarget(BuildTarget.WSAPlayer);
+                EditorUserBuildSettings.SwitchActiveBuildTarget(BuildTargetGroup.WSA, BuildTarget.WSAPlayer);
                 EditorUserBuildSettings.wsaSDK = WSASDK.UWP;
             }
             if (Values[ProjectSetting.WsaUwpBuildToD3D])


### PR DESCRIPTION
… target)

because SwitchActiveBuildTarget(BuildTarget target) is deprecated