### PR TITLE
Fixes issue with tap to place not working

### DIFF
--- a/Assets/HoloToolkit/SpatialMapping/Scripts/TapToPlace.cs
+++ b/Assets/HoloToolkit/SpatialMapping/Scripts/TapToPlace.cs
@@ -64,7 +64,11 @@ namespace HoloToolkit.Unity.SpatialMapping
 
             if (anchorManager != null && spatialMappingManager != null)
             {
-                anchorManager.AttachAnchor(gameObject, SavedAnchorFriendlyName);
+                // If we are not starting out with actively placing the object, give it a World Anchor
+                if(!IsBeingPlaced)
+                {
+                    anchorManager.AttachAnchor(gameObject, SavedAnchorFriendlyName);
+                }
             }
             else
             {


### PR DESCRIPTION
Tap to place currently sets a world anchor on game object during start
method, which keeps it from moving around if starting out with
IsBeingPlaced true.  I put a check to see if we are starting out
placing, and if so, then we don't add the world anchor.

#535 is resolved by this PR