### PR TITLE
Modified SpeechInputSource and KeywordManager so that keybindings are usable when in Editor

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Voice/KeywordManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Voice/KeywordManager.cs
@@ -46,6 +46,8 @@ namespace HoloToolkit.Unity.InputModule
         private KeywordRecognizer keywordRecognizer;
         private readonly Dictionary<string, UnityEvent> responses = new Dictionary<string, UnityEvent>();
 
+        private bool keyBindingsOnly = false;
+
         void Start()
         {
             int keywordCount = KeywordsAndResponses.Length;
@@ -75,6 +77,11 @@ namespace HoloToolkit.Unity.InputModule
                 {
                     Debug.LogError("Duplicate keywords specified in the Inspector on " + gameObject.name + ".");
                 }
+                catch (UnityException ue)
+                {
+                    Debug.LogWarning("Something went wrong when tried to initialize KeywordRecognizer.\r\nFalling back to key bindings.\r\n" + ue);
+                    keyBindingsOnly = true;
+                }
             }
             else
             {
@@ -84,7 +91,7 @@ namespace HoloToolkit.Unity.InputModule
 
         void Update()
         {
-            if (keywordRecognizer != null && keywordRecognizer.IsRunning)
+            if ((keywordRecognizer != null && keywordRecognizer.IsRunning) || keyBindingsOnly)
             {
                 ProcessKeyBindings();
             }
@@ -149,6 +156,10 @@ namespace HoloToolkit.Unity.InputModule
             {
                 keywordRecognizer.Start();
             }
+            else
+            {
+                keyBindingsOnly = true;
+            }
         }
 
         /// <summary>
@@ -160,6 +171,10 @@ namespace HoloToolkit.Unity.InputModule
             if (keywordRecognizer != null && keywordRecognizer.IsRunning)
             {
                 keywordRecognizer.Stop();
+            }
+            else
+            {
+                keyBindingsOnly = false;
             }
         }
     }

--- a/Assets/HoloToolkit/Input/Scripts/Voice/SpeechInputSource.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Voice/SpeechInputSource.cs
@@ -44,6 +44,8 @@ namespace HoloToolkit.Unity.InputModule
 
         private SpeechKeywordRecognizedEventData speechKeywordRecognizedEventData;
 
+        private bool keyBindingsOnly = false;
+
         protected override void Start()
         {
             base.Start();
@@ -53,17 +55,25 @@ namespace HoloToolkit.Unity.InputModule
             int keywordCount = Keywords.Length;
             if (keywordCount > 0)
             {
-                string[] keywords = new string[keywordCount];
-                for (int index = 0; index < keywordCount; index++)
+                try
                 {
-                    keywords[index] = Keywords[index].Keyword;
-                }
-                keywordRecognizer = new KeywordRecognizer(keywords);
-                keywordRecognizer.OnPhraseRecognized += KeywordRecognizer_OnPhraseRecognized;
+                    string[] keywords = new string[keywordCount];
+                    for (int index = 0; index < keywordCount; index++)
+                    {
+                        keywords[index] = Keywords[index].Keyword;
+                    }
+                    keywordRecognizer = new KeywordRecognizer(keywords);
+                    keywordRecognizer.OnPhraseRecognized += KeywordRecognizer_OnPhraseRecognized;
 
-                if (RecognizerStart == RecognizerStartBehavior.AutoStart)
+                    if (RecognizerStart == RecognizerStartBehavior.AutoStart)
+                    {
+                        keywordRecognizer.Start();
+                    }
+                } 
+                catch (UnityException ue)
                 {
-                    keywordRecognizer.Start();
+                    Debug.LogWarning("Something went wrong when tried to initialize KeywordRecognizer.\r\nFalling back to key bindings.\r\n" + ue);
+                    keyBindingsOnly = true;
                 }
             }
             else
@@ -74,7 +84,7 @@ namespace HoloToolkit.Unity.InputModule
 
         protected virtual void Update()
         {
-            if (keywordRecognizer != null && keywordRecognizer.IsRunning)
+            if ((keywordRecognizer != null && keywordRecognizer.IsRunning) || keyBindingsOnly)
             {
                 ProcessKeyBindings();
             }
@@ -132,6 +142,10 @@ namespace HoloToolkit.Unity.InputModule
             {
                 keywordRecognizer.Start();
             }
+            else
+            {
+                keyBindingsOnly = true;
+            }
         }
 
         /// <summary>
@@ -143,6 +157,10 @@ namespace HoloToolkit.Unity.InputModule
             if (keywordRecognizer != null && keywordRecognizer.IsRunning)
             {
                 keywordRecognizer.Stop();
+            }
+            else
+            {
+                keyBindingsOnly = false;
             }
         }
 


### PR DESCRIPTION
Using voice commands inside Editor ends up with an error "Speech recognition is not supported on this machine. " and as there are no fallbacks nor exception handling regarding that both `SpeechInputHandler` and `KeywordManager` fail and eventually voice can't be tested inside Editor at all. The code here fixes it so a developer would have at least key bindinngs working for voice commands while in Editor.