### PR TITLE
Make it optional that TapToPlace takes control of the DrawMesh on the…

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Interactions/TapToPlace.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Interactions/TapToPlace.cs
@@ -38,8 +38,8 @@ namespace HoloToolkit.Unity.InputModule
         [Tooltip("Setting this to true will enable the user to move and place the object in the scene without needing to tap on the object. Useful when you want to place an object immediately.")]
         public bool IsBeingPlaced;
 
-        [Tooltip("Setting this to true will this behavior control the DrawMesh property on the spatial mapping")]
-        public bool ControlDrawMeshOnSpatialMappingWhenBeeingPlaced = true;
+        [Tooltip("Setting this to true will allow this behavior to control the DrawMesh property on the spatial mapping.")]
+        public bool AllowMeshVisualizationControl = true;
 
         /// <summary>
         /// The default ignore raycast layer built into unity.
@@ -127,7 +127,7 @@ namespace HoloToolkit.Unity.InputModule
                 InputManager.Instance.AddGlobalListener(gameObject);
 
                 // If the user is in placing mode, display the spatial mapping mesh.
-                if (ControlDrawMeshOnSpatialMappingWhenBeeingPlaced)
+                if (AllowMeshVisualizationControl)
                 {
                     SpatialMappingManager.Instance.DrawVisualMeshes = true;
                 }
@@ -145,7 +145,7 @@ namespace HoloToolkit.Unity.InputModule
                 InputManager.Instance.RemoveGlobalListener(gameObject);
 
                 // If the user is not in placing mode, hide the spatial mapping mesh.
-                if (ControlDrawMeshOnSpatialMappingWhenBeeingPlaced)
+                if (AllowMeshVisualizationControl)
                 {
                     SpatialMappingManager.Instance.DrawVisualMeshes = false;
                 }

--- a/Assets/HoloToolkit/Input/Scripts/Interactions/TapToPlace.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Interactions/TapToPlace.cs
@@ -38,6 +38,9 @@ namespace HoloToolkit.Unity.InputModule
         [Tooltip("Setting this to true will enable the user to move and place the object in the scene without needing to tap on the object. Useful when you want to place an object immediately.")]
         public bool IsBeingPlaced;
 
+        [Tooltip("Setting this to true will this behavior control the DrawMesh property on the spatial mapping")]
+        public bool ControlDrawMeshOnSpatialMappingWhenBeeingPlaced = true;
+
         /// <summary>
         /// The default ignore raycast layer built into unity.
         /// </summary>
@@ -124,7 +127,10 @@ namespace HoloToolkit.Unity.InputModule
                 InputManager.Instance.AddGlobalListener(gameObject);
 
                 // If the user is in placing mode, display the spatial mapping mesh.
-                SpatialMappingManager.Instance.DrawVisualMeshes = true;
+                if (ControlDrawMeshOnSpatialMappingWhenBeeingPlaced)
+                {
+                    SpatialMappingManager.Instance.DrawVisualMeshes = true;
+                }
 #if UNITY_WSA && !UNITY_EDITOR
 
                 //Removes existing world anchor if any exist.
@@ -139,7 +145,10 @@ namespace HoloToolkit.Unity.InputModule
                 InputManager.Instance.RemoveGlobalListener(gameObject);
 
                 // If the user is not in placing mode, hide the spatial mapping mesh.
-                SpatialMappingManager.Instance.DrawVisualMeshes = false;
+                if (ControlDrawMeshOnSpatialMappingWhenBeeingPlaced)
+                {
+                    SpatialMappingManager.Instance.DrawVisualMeshes = false;
+                }
 #if UNITY_WSA && !UNITY_EDITOR
 
                 // Add world anchor when object placement is done.


### PR DESCRIPTION
Make it optional that TapToPlace takes control of the DrawMesh on the SpatialMappingManager

we had a scenario where we always had to show the drawmesh to true with our own matertial. its annoying that tap to place start changing this behavior