### PR TITLE
improvements for ImportExportAnchorManager 

### DIFF
--- a/Assets/HoloToolkit-Tests/Sharing/Scripts/ImportExportAnchorManager.cs
+++ b/Assets/HoloToolkit-Tests/Sharing/Scripts/ImportExportAnchorManager.cs
@@ -499,6 +499,7 @@ namespace HoloToolkit.Sharing.Tests
                 // If we have a room, we'll join the first room we see.
                 // If we are the user with the lowest user ID, we will create the room.
                 // Otherwise we will wait for the room to be created.
+                yield return new WaitForEndOfFrame();
                 if (roomManager.GetRoomCount() == 0)
                 {
                     if (ShouldLocalUserCreateRoom)

--- a/Assets/HoloToolkit-Tests/Sharing/Scripts/ImportExportAnchorManager.cs
+++ b/Assets/HoloToolkit-Tests/Sharing/Scripts/ImportExportAnchorManager.cs
@@ -29,6 +29,7 @@ namespace HoloToolkit.Sharing.Tests
             Start,
             Failed,
             Ready,
+            RoomApiInitializing,
             RoomApiInitialized,
             AnchorEstablished,
             // AnchorStore states
@@ -489,6 +490,7 @@ namespace HoloToolkit.Sharing.Tests
         /// </summary>
         private IEnumerator InitRoomApi()
         {
+            currentState = ImportExportState.RoomApiInitializing;
             // First check if there is a current room
             currentRoom = roomManager.GetCurrentRoom();
 


### PR DESCRIPTION
Fixes https://github.com/Microsoft/HoloToolkit-Unity/issues/652
- sometimes InitRoomApi was called twice. this is beeing avoided now
- GetRoomCount is giving 0 sometimes when there are rooms, causing a extra room is created. added a slight delay that seems to fix the issue