### PR TITLE
[RS2] Build & Deploy Window Fixes 

### DIFF
--- a/Assets/HoloToolkit/Build/Editor/BuildDeployPortal.cs
+++ b/Assets/HoloToolkit/Build/Editor/BuildDeployPortal.cs
@@ -4,7 +4,6 @@
 //
 
 using UnityEngine;
-using System.Collections;
 using System.Net;
 using System;
 using System.IO;
@@ -419,7 +418,7 @@ namespace HoloToolkit.Unity
                     // Open it up in default text editor
                     System.Diagnostics.Process.Start(logFile);
                 }
-                catch (System.Exception ex)
+                catch (Exception ex)
                 {
                     Debug.LogError(ex.ToString());
                     return false;

--- a/Assets/HoloToolkit/Build/Editor/BuildDeployPrefs.cs
+++ b/Assets/HoloToolkit/Build/Editor/BuildDeployPrefs.cs
@@ -9,7 +9,6 @@ using UnityEngine;
 
 namespace HoloToolkit.Unity
 {
-
     public static class BuildDeployPrefs
     {
         // Constants
@@ -28,45 +27,54 @@ namespace HoloToolkit.Unity
             get { return GetEditorPref(EditorPrefs_BuildDir, "WindowsStoreApp"); }
             set { EditorPrefs.SetString(EditorPrefs_BuildDir, value); }
         }
+
         public static string AbsoluteBuildDirectory
         {
             get { return Path.GetFullPath(Path.Combine(Path.Combine(Application.dataPath, ".."), BuildDirectory)); }
         }
+
         public static string MsBuildVersion
         {
             get { return GetEditorPref(EditorPrefs_MSBuildVer, BuildDeployTools.DefaultMSBuildVersion); }
             set { EditorPrefs.SetString(EditorPrefs_MSBuildVer, value); }
         }
+
         public static string BuildConfig
         {
             get { return GetEditorPref(EditorPrefs_BuildConfig, "Debug"); }
             set { EditorPrefs.SetString(EditorPrefs_BuildConfig, value); }
         }
+
         public static bool ForceRebuild
         {
             get { return GetEditorPref(EditorPrefs_ForceRebuild, false); }
             set { EditorPrefs.SetBool(EditorPrefs_ForceRebuild, value); }
         }
+
         public static bool IncrementBuildVersion
         {
             get { return GetEditorPref(EditorPrefs_IncrementBuildVersion, true); }
             set { EditorPrefs.SetBool(EditorPrefs_IncrementBuildVersion, value); }
         }
+
         public static string TargetIPs
         {
             get { return GetEditorPref(EditorPrefs_TargetIPs, "127.0.0.1"); }
             set { EditorPrefs.SetString(EditorPrefs_TargetIPs, value); }
         }
+
         public static string DeviceUser
         {
             get { return GetEditorPref(EditorPrefs_DeviceUser, ""); }
             set { EditorPrefs.SetString(EditorPrefs_DeviceUser, value); }
         }
+
         public static string DevicePassword
         {
             get { return GetEditorPref(EditorPrefs_DevicePwd, ""); }
             set { EditorPrefs.SetString(EditorPrefs_DevicePwd, value); }
         }
+
         public static bool FullReinstall
         {
             get { return GetEditorPref(EditorPrefs_FullReinstall, true); }
@@ -79,11 +87,9 @@ namespace HoloToolkit.Unity
             {
                 return EditorPrefs.GetString(key);
             }
-            else
-            {
-                EditorPrefs.SetString(key, defaultValue);
-                return defaultValue;
-            }
+
+            EditorPrefs.SetString(key, defaultValue);
+            return defaultValue;
         }
 
         private static bool GetEditorPref(string key, bool defaultValue)
@@ -92,11 +98,9 @@ namespace HoloToolkit.Unity
             {
                 return EditorPrefs.GetBool(key);
             }
-            else
-            {
-                EditorPrefs.SetBool(key, defaultValue);
-                return defaultValue;
-            }
+
+            EditorPrefs.SetBool(key, defaultValue);
+            return defaultValue;
         }
     }
 }

--- a/Assets/HoloToolkit/Build/Editor/BuildDeployTools.cs
+++ b/Assets/HoloToolkit/Build/Editor/BuildDeployTools.cs
@@ -5,9 +5,7 @@
 
 using System;
 using System.IO;
-using System.Xml;
 using System.Linq;
-using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 using System.Xml.Linq;
@@ -19,23 +17,22 @@ namespace HoloToolkit.Unity
     /// </summary>
     public class BuildDeployTools
     {
-        // Consts
-        public static readonly string DefaultMSBuildVersion = "15.0";
+        public static readonly string DefaultMSBuildVersion = "14.0";
 
-        // Functions
         public static bool BuildSLN(string buildDirectory, bool showConfDlg = true)
         {
             // Use BuildSLNUtilities to create the SLN
             bool buildSuccess = false;
 
-            var buildInfo = new BuildSLNUtilities.BuildInfo()
+            var buildInfo = new BuildInfo
             {
                 // These properties should all match what the Standalone.proj file specifies
                 OutputDirectory = buildDirectory,
                 Scenes = EditorBuildSettings.scenes.Where(scene => scene.enabled).Select(scene => scene.path),
                 BuildTarget = BuildTarget.WSAPlayer,
                 WSASdk = WSASDK.UWP,
-                WSAUWPBuildType = WSAUWPBuildType.D3D,
+                WSAUWPBuildType = EditorUserBuildSettings.wsaUWPBuildType,
+                WSAUwpSdk = EditorUserBuildSettings.wsaUWPSDK,
 
                 // Configure a post build action that will compile the generated solution
                 PostBuildAction = (innerBuildInfo, buildError) =>
@@ -48,8 +45,18 @@ namespace HoloToolkit.Unity
                     {
                         if (showConfDlg)
                         {
-                            EditorUtility.DisplayDialog(PlayerSettings.productName, "Build Complete", "OK");
+                            if (!EditorUtility.DisplayDialog(PlayerSettings.productName, "Build Complete", "OK", "Build AppX"))
+                            {
+                                BuildAppxFromSLN(
+                                    PlayerSettings.productName,
+                                    BuildDeployPrefs.MsBuildVersion,
+                                    BuildDeployPrefs.ForceRebuild,
+                                    BuildDeployPrefs.BuildConfig,
+                                    BuildDeployPrefs.BuildDirectory,
+                                    BuildDeployPrefs.IncrementBuildVersion);
+                            }
                         }
+
                         buildSuccess = true;
                     }
                 }
@@ -64,50 +71,120 @@ namespace HoloToolkit.Unity
 
         public static string CalcMSBuildPath(string msBuildVersion)
         {
-            // TODO: robertes: If this is going to support msbuild 15 and beyond, it needs to be updated to use the COM or powershell interfaces to find msbuild.
-            //                 See: https://github.com/Microsoft/vssetup.powershell/wiki
-            using (Microsoft.Win32.RegistryKey key = Microsoft.Win32.Registry.LocalMachine.OpenSubKey(string.Format(@"Software\Microsoft\MSBuild\ToolsVersions\{0}", msBuildVersion)))
+            if (msBuildVersion.Equals("14.0"))
             {
-                if (key == null)
+                using (Microsoft.Win32.RegistryKey key =
+                    Microsoft.Win32.Registry.LocalMachine.OpenSubKey(
+                        string.Format(@"Software\Microsoft\MSBuild\ToolsVersions\{0}", msBuildVersion)))
                 {
-                    return null;
+                    if (key == null)
+                    {
+                        return null;
+                    }
+
+                    var msBuildBinFolder = (string)key.GetValue("MSBuildToolsPath");
+                    return Path.Combine(msBuildBinFolder, "msbuild.exe");
                 }
-                string msBuildBinFolder = key.GetValue("MSBuildToolsPath") as string;
-                string msBuildPath = Path.Combine(msBuildBinFolder, "msbuild.exe");
-                return msBuildPath;
             }
+
+            // For MSBuild 15+ we should to use vswhere to give us the correct instance
+            string output = @"/C cd ""%ProgramFiles(x86)%\Microsoft Visual Studio\Installer"" && vswhere -version " + msBuildVersion + " -products * -requires Microsoft.Component.MSBuild -property installationPath";
+
+            var vswherePInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "cmd.exe",
+                CreateNoWindow = true,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                Arguments = output
+            };
+
+            using (var vswhereP = new System.Diagnostics.Process())
+            {
+                vswhereP.StartInfo = vswherePInfo;
+                vswhereP.Start();
+                output = vswhereP.StandardOutput.ReadToEnd();
+                vswhereP.WaitForExit();
+                vswhereP.Close();
+                vswhereP.Dispose();
+            }
+
+            output = output + @"\MSBuild\" + msBuildVersion + @"\Bin\MSBuild.exe";
+            output = output.Replace(Environment.NewLine, "");
+            return output;
         }
 
-        public static bool BuildAppxFromSolution(string productName, string msBuildVersion, bool forceRebuildAppx, string buildConfig, string buildDirectory, bool incrementVersion)
+        public static bool RestoreNugetPackages(string nugetPath, string storePath)
         {
+            var nugetPInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = nugetPath,
+                CreateNoWindow = true,
+                UseShellExecute = false,
+                Arguments = "restore \"" + storePath + "/project.json\""
+            };
+
+            using (var nugetP = new System.Diagnostics.Process())
+            {
+                nugetP.StartInfo = nugetPInfo;
+                nugetP.Start();
+                nugetP.WaitForExit();
+                nugetP.Close();
+                nugetP.Dispose();
+            }
+
+            return File.Exists(storePath + "\\project.lock.json");
+        }
+
+        public static bool BuildAppxFromSLN(string productName, string msBuildVersion, bool forceRebuildAppx, string buildConfig, string buildDirectory, bool incrementVersion, bool showConfDlg = true)
+        {
+            EditorUtility.DisplayProgressBar("Build AppX", "Building AppX Package...", 0);
+            string slnFilename = Path.Combine(buildDirectory, PlayerSettings.productName + ".sln");
+
+            if (!File.Exists(slnFilename))
+            {
+                Debug.LogError("Unabel to find Solution to build from!");
+                EditorUtility.ClearProgressBar();
+                return false;
+            }
+
             // Get and validate the msBuild path...
-            string vs = CalcMSBuildPath(msBuildVersion);
+            var vs = CalcMSBuildPath(msBuildVersion);
+
             if (!File.Exists(vs))
             {
                 Debug.LogError("MSBuild.exe is missing or invalid (path=" + vs + "). Note that the default version is " + DefaultMSBuildVersion);
+                EditorUtility.ClearProgressBar();
                 return false;
             }
 
             // Get the path to the NuGet tool
             string unity = Path.GetDirectoryName(EditorApplication.applicationPath);
-            string nugetPath = Path.Combine(unity, @"Data\PlaybackEngines\MetroSupport\Tools\NuGet.exe");
+            System.Diagnostics.Debug.Assert(unity != null, "unity != null");
             string storePath = Path.GetFullPath(Path.Combine(Path.Combine(Application.dataPath, ".."), buildDirectory));
             string solutionProjectPath = Path.GetFullPath(Path.Combine(storePath, productName + @".sln"));
 
+            // Bug in Unity editor that doesn't copy project.json and project.lock.json files correctly if solutionProjectPath is not in a folder named UWP.
+            if (!File.Exists(storePath + "\\project.json"))
+            {
+                File.Copy(unity + @"\Data\PlaybackEngines\MetroSupport\Tools\project.json", storePath + "\\project.json");
+            }
+
+            string nugetPath = Path.Combine(unity, @"Data\PlaybackEngines\MetroSupport\Tools\NuGet.exe");
+
             // Before building, need to run a nuget restore to generate a json.lock file. Failing to do
             // this breaks the build in VS RTM
-            var nugetPInfo = new System.Diagnostics.ProcessStartInfo();
-            nugetPInfo.FileName = nugetPath;
-            nugetPInfo.WorkingDirectory = buildDirectory;
-            nugetPInfo.UseShellExecute = false;
-            nugetPInfo.Arguments = @"restore " + PlayerSettings.productName + "/project.json";
-            using (var nugetP = new System.Diagnostics.Process())
+            if (!RestoreNugetPackages(nugetPath, storePath) ||
+                !RestoreNugetPackages(nugetPath, storePath + "\\" + productName) ||
+                EditorUserBuildSettings.wsaGenerateReferenceProjects && !RestoreNugetPackages(nugetPath, storePath + "/GeneratedProjects/UWP/Assembly-CSharp") ||
+                EditorUserBuildSettings.wsaGenerateReferenceProjects && !RestoreNugetPackages(nugetPath, storePath + "/GeneratedProjects/UWP/Assembly-CSharp-firstpass"))
             {
-                Debug.Log(nugetPath + " " + nugetPInfo.Arguments);
-                nugetP.StartInfo = nugetPInfo;
-                nugetP.Start();
-                nugetP.WaitForExit();
+                Debug.LogError("Failed to restore nuget packages");
+                EditorUtility.ClearProgressBar();
+                return false;
             }
+
+            EditorUtility.DisplayProgressBar("Build AppX", "Building AppX Package...", 25);
 
             // Ensure that the generated .appx version increments by modifying
             // Package.appxmanifest
@@ -117,54 +194,77 @@ namespace HoloToolkit.Unity
             }
 
             // Now do the actual build
-            var pinfo = new System.Diagnostics.ProcessStartInfo();
-            pinfo.FileName = vs;
-            pinfo.UseShellExecute = false;
-            string buildType = forceRebuildAppx ? "Rebuild" : "Build";
-            pinfo.Arguments = string.Format("\"{0}\" /t:{2} /p:Configuration={1} /p:Platform=x86", solutionProjectPath, buildConfig, buildType);
-            var p = new System.Diagnostics.Process();
-
-            Debug.Log(vs + " " + pinfo.Arguments);
-            p.StartInfo = pinfo;
-            p.Start();
-
-            p.WaitForExit();
-            if (p.ExitCode == 0)
+            var pinfo = new System.Diagnostics.ProcessStartInfo
             {
-                Debug.Log("APPX build succeeded!");
+                FileName = vs,
+                CreateNoWindow = false,
+                Arguments = string.Format("\"{0}\" /t:{2} /p:Configuration={1} /p:Platform=x86 /verbosity:m",
+                    solutionProjectPath,
+                    buildConfig,
+                    forceRebuildAppx ? "Rebuild" : "Build")
+            };
+
+            // Uncomment out to debug by copying into command window
+            //Debug.Log("\"" + vs + "\"" + " " + pinfo.Arguments);
+
+            var process = new System.Diagnostics.Process { StartInfo = pinfo };
+
+            try
+            {
+                if (!process.Start())
+                {
+                    Debug.LogError("Failed to start Cmd process!");
+                    EditorUtility.ClearProgressBar();
+                    return false;
+                }
+
+                process.WaitForExit();
+
+                EditorUtility.ClearProgressBar();
+
+                if (process.ExitCode == 0 &&
+                    showConfDlg &&
+                    !EditorUtility.DisplayDialog("Build AppX", "AppX Build Successful!", "OK", "Open Project Folder"))
+                {
+                    System.Diagnostics.Process.Start("explorer.exe", "/select," + storePath);
+                }
+
+                if (process.ExitCode != 0)
+                {
+                    Debug.LogError("MSBuild error (code = " + process.ExitCode + ")");
+                    EditorUtility.DisplayDialog(PlayerSettings.productName + " build Failed!", "Failed to build appx from solution. Error code: " + process.ExitCode, "OK");
+                    return false;
+                }
+
+                process.Close();
+                process.Dispose();
+
             }
-            else
+            catch (Exception e)
             {
-                Debug.LogError("MSBuild error (code = " + p.ExitCode + ")");
-            }
-
-            if (p.ExitCode != 0)
-            {
-                EditorUtility.DisplayDialog(PlayerSettings.productName + " build Failed!", "Failed to build appx from solution. Error code: " + p.ExitCode, "OK");
+                Debug.LogError("Cmd Process EXCEPTION: " + e);
+                EditorUtility.ClearProgressBar();
                 return false;
             }
-            else
-            {
-                // Build succeeded. Allow user to install build on remote PC
-                BuildDeployWindow.OpenWindow();
-                return true;
-            }
+
+            return true;
         }
 
         private static void IncrementPackageVersion()
         {
             // Find the manifest, assume the one we want is the first one
             string[] manifests = Directory.GetFiles(BuildDeployPrefs.AbsoluteBuildDirectory, "Package.appxmanifest", SearchOption.AllDirectories);
+
             if (manifests.Length == 0)
             {
                 Debug.LogError("Unable to find Package.appxmanifest file for build (in path - " + BuildDeployPrefs.AbsoluteBuildDirectory + ")");
                 return;
             }
-            string manifest = manifests[0];
 
-            XElement rootNode = XElement.Load(manifest);
-            XNamespace ns = rootNode.GetDefaultNamespace();
-            var identityNode = rootNode.Element(ns + "Identity");
+            string manifest = manifests[0];
+            var rootNode = XElement.Load(manifest);
+            var identityNode = rootNode.Element(rootNode.GetDefaultNamespace() + "Identity");
+
             if (identityNode == null)
             {
                 Debug.LogError("Package.appxmanifest for build (in path - " + BuildDeployPrefs.AbsoluteBuildDirectory + ") is missing an <Identity /> node");
@@ -175,6 +275,7 @@ namespace HoloToolkit.Unity
             // when we pass in the string "Version", the program doesn't find the attribute.
             // Best guess as to why this happens is that implicit string conversion doesn't set the namespace to empty
             var versionAttr = identityNode.Attribute(XName.Get("Version"));
+
             if (versionAttr == null)
             {
                 Debug.LogError("Package.appxmanifest for build (in path - " + BuildDeployPrefs.AbsoluteBuildDirectory + ") is missing a version attribute in the <Identity /> node.");

--- a/Assets/HoloToolkit/Build/Editor/BuildDeployWindow.cs
+++ b/Assets/HoloToolkit/Build/Editor/BuildDeployWindow.cs
@@ -1,17 +1,18 @@
-//
+﻿//
 // Copyright (c) @jevertt
 // Copyright (c) Rafael Rivera
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 //
 
-using System.IO;
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using System.Xml;
 using UnityEditor;
 using UnityEngine;
-using System.Net;
-using System;
-using System.Xml;
+using Debug = UnityEngine.Debug;
 
 namespace HoloToolkit.Unity
 {
@@ -25,54 +26,118 @@ namespace HoloToolkit.Unity
         private const string GUIHorizSpacer = "     ";
         private const float UpdateBuildsPeriod = 1.0f;
 
-        // Properties
+        private enum BuildConfigEnum
+        {
+            DEBUG = 0,
+            RELEASE = 1,
+            MASTER = 2
+        }
+
+        #region Properties
+
         private bool ShouldOpenSLNBeEnabled { get { return !string.IsNullOrEmpty(BuildDeployPrefs.BuildDirectory); } }
-        private bool ShouldBuildSLNBeEnabled { get { return !string.IsNullOrEmpty(BuildDeployPrefs.BuildDirectory); } }
+
+        private bool ShouldBuildSLNBeEnabled { get { return !string.IsNullOrEmpty(BuildDeployPrefs.BuildDirectory) && !string.IsNullOrEmpty(PlayerSettings.WSA.certificatePath); } }
+
         private bool ShouldBuildAppxBeEnabled
         {
-            get { return 
-                    !string.IsNullOrEmpty(BuildDeployPrefs.BuildDirectory) && 
-                    !string.IsNullOrEmpty(BuildDeployPrefs.MsBuildVersion) && 
-                    !string.IsNullOrEmpty(BuildDeployPrefs.BuildConfig); }
+            get
+            {
+                return ShouldBuildSLNBeEnabled &&
+                  !string.IsNullOrEmpty(BuildDeployPrefs.BuildDirectory) &&
+                  !string.IsNullOrEmpty(BuildDeployPrefs.MsBuildVersion) &&
+                  !string.IsNullOrEmpty(BuildDeployPrefs.BuildConfig);
+            }
         }
+
         private bool ShouldLaunchAppBeEnabled
         {
             get { return !string.IsNullOrEmpty(BuildDeployPrefs.TargetIPs) && !string.IsNullOrEmpty(BuildDeployPrefs.BuildDirectory); }
         }
+
         private bool ShouldWebPortalBeEnabled
         {
             get { return !string.IsNullOrEmpty(BuildDeployPrefs.TargetIPs) && !string.IsNullOrEmpty(BuildDeployPrefs.BuildDirectory); }
         }
+
         private bool ShouldLogViewBeEnabled
         {
             get { return !string.IsNullOrEmpty(BuildDeployPrefs.TargetIPs) && !string.IsNullOrEmpty(BuildDeployPrefs.BuildDirectory); }
         }
+
         private bool LocalIPsOnly { get { return true; } }
 
-        // Privates
-        private List<string> builds = new List<string>();
-        private float timeLastUpdatedBuilds = 0.0f;
+        private bool HoloLensUsbConnected
+        {
+            get
+            {
+                bool isConnected = false;
 
-        // Functions
+                if (USBDeviceListener.USBDevices != null)
+                {
+                    foreach (USBDeviceInfo device in USBDeviceListener.USBDevices)
+                    {
+                        if (device.Name.Equals("Microsoft HoloLens"))
+                        {
+                            isConnected = true;
+                        }
+                    }
+                }
+                else
+                {
+                    isConnected = SessionState.GetBool("HoloLensUsbConnected", false);
+                }
+
+                SessionState.SetBool("HoloLensUsbConnected", isConnected);
+                return isConnected;
+            }
+        }
+
+        #endregion // Properties
+
+        #region Fields
+
+        private List<string> builds = new List<string>();
+        private float timeLastUpdatedBuilds;
+        private string[] windowsSdkPaths;
+        private Vector2 scrollPosition;
+        private string wsaCertPath;
+
+        #endregion // Fields
+
+        #region Methods
+
         [MenuItem("HoloToolkit/Build Window", false, 0)]
         public static void OpenWindow()
         {
-            BuildDeployWindow window = GetWindow<BuildDeployWindow>("Build Window") as BuildDeployWindow;
+            var window = GetWindow<BuildDeployWindow>("Build Window");
+
             if (window != null)
             {
                 window.Show();
             }
         }
 
-        void OnEnable()
+        private void OnEnable()
         {
             Setup();
         }
 
         private void Setup()
         {
-            this.titleContent = new GUIContent("Build Window");
-            this.minSize = new Vector2(600, 200);
+            titleContent = new GUIContent("Build Window");
+            minSize = new Vector2(600, 575);
+
+            windowsSdkPaths = Directory.GetDirectories(@"C:\Program Files (x86)\Windows Kits\10\Lib");
+
+            for (int i = 0; i < windowsSdkPaths.Length; i++)
+            {
+                windowsSdkPaths[i] = windowsSdkPaths[i].Substring(windowsSdkPaths[i].LastIndexOf(@"\", StringComparison.Ordinal) + 1);
+            }
+
+            wsaCertPath = PlayerSettings.WSA.certificatePath;
+            wsaCertPath = wsaCertPath.Replace("\\", "/");
+            wsaCertPath = wsaCertPath.Substring(wsaCertPath.LastIndexOf("/", StringComparison.Ordinal) + 1);
 
             UpdateXdeStatus();
             UpdateBuilds();
@@ -91,7 +156,57 @@ namespace HoloToolkit.Unity
             int buttonWidth_Quarter = Screen.width / 4;
             int buttonWidth_Half = Screen.width / 2;
             int buttonWidth_Full = Screen.width - 25;
-            string appName = PlayerSettings.productName;
+            var locatorHasData = XdeGuestLocator.HasData;
+            var locatorIsSearching = XdeGuestLocator.IsSearching;
+            var xdeGuestIpAddress = XdeGuestLocator.GuestIpAddress;
+
+            // Quick Options
+            GUILayout.BeginVertical();
+            GUILayout.Label("Quick Options");
+
+            EditorGUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+            EditorGUILayout.EndHorizontal();
+
+            // Build & Run button...
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                GUILayout.FlexibleSpace();
+                GUI.enabled = ShouldBuildSLNBeEnabled;
+
+                if (GUILayout.Button((!locatorIsSearching && locatorHasData || HoloLensUsbConnected)
+                    ? "Build SLN, Build APPX, then Install"
+                    : "Build SLN, Build APPX",
+                    GUILayout.Width(buttonWidth_Half - 20)))
+                {
+                    // Build SLN
+                    EditorApplication.delayCall += () => { BuildAll(!locatorIsSearching && locatorHasData); };
+                }
+
+                GUI.enabled = true;
+
+                if (GUILayout.Button("Open Player Settings", GUILayout.Width(buttonWidth_Quarter)))
+                {
+                    EditorApplication.ExecuteMenuItem("Edit/Project Settings/Player");
+                }
+
+                if (GUILayout.Button(string.IsNullOrEmpty(wsaCertPath) ? "Select Certificate" : wsaCertPath, GUILayout.Width(buttonWidth_Quarter)))
+                {
+                    string path = EditorUtility.OpenFilePanel("Select Certificate", Application.dataPath, "pfx");
+                    wsaCertPath = path.Substring(path.LastIndexOf("/", StringComparison.Ordinal) + 1);
+
+                    if (!string.IsNullOrEmpty(path))
+                    {
+                        CertificatePasswordWindow.Show(path);
+                    }
+                    else
+                    {
+                        PlayerSettings.WSA.SetCertificate(string.Empty, string.Empty);
+                    }
+                }
+            }
+
+            GUILayout.EndVertical();
 
             // Build section
             GUILayout.BeginVertical();
@@ -104,6 +219,7 @@ namespace HoloToolkit.Unity
             // Build directory (and save setting, if it's changed)
             string curBuildDirectory = BuildDeployPrefs.BuildDirectory;
             string newBuildDirectory = EditorGUILayout.TextField(GUIHorizSpacer + "Build directory", curBuildDirectory);
+
             if (newBuildDirectory != curBuildDirectory)
             {
                 BuildDeployPrefs.BuildDirectory = newBuildDirectory;
@@ -114,15 +230,33 @@ namespace HoloToolkit.Unity
             using (new EditorGUILayout.HorizontalScope())
             {
                 GUILayout.FlexibleSpace();
+
+                float previousLabelWidth = EditorGUIUtility.labelWidth;
+
+                // Generate C# Project References
+                EditorGUIUtility.labelWidth = 105;
+                bool generateReferenceProjects = EditorUserBuildSettings.wsaGenerateReferenceProjects;
+                bool shouldGenerateProjects = EditorGUILayout.Toggle("Unity C# Projects", generateReferenceProjects);
+
+                if (shouldGenerateProjects != generateReferenceProjects)
+                {
+                    EditorUserBuildSettings.wsaGenerateReferenceProjects = shouldGenerateProjects;
+                }
+
+                // Restore previous label width
+                EditorGUIUtility.labelWidth = previousLabelWidth;
+
                 GUI.enabled = ShouldOpenSLNBeEnabled;
+
                 if (GUILayout.Button("Open SLN", GUILayout.Width(buttonWidth_Quarter)))
                 {
                     // Open SLN
                     string slnFilename = Path.Combine(curBuildDirectory, PlayerSettings.productName + ".sln");
+
                     if (File.Exists(slnFilename))
                     {
-                        FileInfo slnFile = new FileInfo(slnFilename);
-                        System.Diagnostics.Process.Start(slnFile.FullName);
+                        var slnFile = new FileInfo(slnFilename);
+                        Process.Start(slnFile.FullName);
                     }
                     else if (EditorUtility.DisplayDialog("Solution Not Found", "We couldn't find the solution. Would you like to Build it?", "Yes, Build", "No"))
                     {
@@ -130,25 +264,15 @@ namespace HoloToolkit.Unity
                         EditorApplication.delayCall += () => { BuildDeployTools.BuildSLN(curBuildDirectory); };
                     }
                 }
+
                 GUI.enabled = ShouldBuildSLNBeEnabled;
+
                 if (GUILayout.Button("Build Visual Studio SLN", GUILayout.Width(buttonWidth_Half)))
                 {
                     // Build SLN
                     EditorApplication.delayCall += () => { BuildDeployTools.BuildSLN(curBuildDirectory); };
                 }
-                GUI.enabled = true;
-            }
 
-            // Build & Run button...
-            using (new EditorGUILayout.HorizontalScope())
-            {
-                GUILayout.FlexibleSpace();
-                GUI.enabled = ShouldBuildSLNBeEnabled;
-                if (GUILayout.Button("Build SLN, Build APPX, then Install", GUILayout.Width(buttonWidth_Half)))
-                {
-                    // Build SLN
-                    EditorApplication.delayCall += () => { BuildAndRun(appName); };
-                }
                 GUI.enabled = true;
             }
 
@@ -156,22 +280,76 @@ namespace HoloToolkit.Unity
             GUILayout.BeginVertical();
             GUILayout.Label("APPX");
 
-            // MSBuild Ver (and save setting, if it's changed)
+            // SDK and MS Build Version(and save setting, if it's changed)
             string curMSBuildVer = BuildDeployPrefs.MsBuildVersion;
-            string newMSBuildVer = EditorGUILayout.TextField(GUIHorizSpacer + "MSBuild Version", curMSBuildVer);
-            if (newMSBuildVer != curMSBuildVer)
+            string currentSDKVersion = EditorUserBuildSettings.wsaUWPSDK;
+
+            int currentSDKVersionIndex = 0;
+            int defaultMSBuildVersionIndex = 0;
+
+            for (var i = 0; i < windowsSdkPaths.Length; i++)
+            {
+                if (string.IsNullOrEmpty(currentSDKVersion))
+                {
+                    currentSDKVersionIndex = windowsSdkPaths.Length - 1;
+                }
+                else
+                {
+                    if (windowsSdkPaths[i].Equals(currentSDKVersion))
+                    {
+                        currentSDKVersionIndex = i;
+                    }
+
+                    if (windowsSdkPaths[i].Equals("10.0.14393.0"))
+                    {
+                        defaultMSBuildVersionIndex = i;
+                    }
+                }
+            }
+
+            currentSDKVersionIndex = EditorGUILayout.Popup(GUIHorizSpacer + "SDK Version", currentSDKVersionIndex, windowsSdkPaths);
+
+            string newSDKVersion = windowsSdkPaths[currentSDKVersionIndex];
+
+            if (!newSDKVersion.Equals(currentSDKVersion))
+            {
+                EditorUserBuildSettings.wsaUWPSDK = newSDKVersion;
+            }
+
+            string newMSBuildVer = currentSDKVersionIndex <= defaultMSBuildVersionIndex ? BuildDeployTools.DefaultMSBuildVersion : "15.0";
+            EditorGUILayout.LabelField(GUIHorizSpacer + "MS Build Version", newMSBuildVer);
+
+            if (!newMSBuildVer.Equals(curMSBuildVer))
             {
                 BuildDeployPrefs.MsBuildVersion = newMSBuildVer;
                 curMSBuildVer = newMSBuildVer;
             }
 
             // Build config (and save setting, if it's changed)
-            string curBuildConfig = BuildDeployPrefs.BuildConfig;
-            string newBuildConfig = EditorGUILayout.TextField(GUIHorizSpacer + "Build Configuration", curBuildConfig);
-            if (newBuildConfig != curBuildConfig)
+            string curBuildConfigString = BuildDeployPrefs.BuildConfig;
+
+            BuildConfigEnum buildConfigOption;
+            if (curBuildConfigString.ToLower().Equals("master"))
+            {
+                buildConfigOption = BuildConfigEnum.MASTER;
+            }
+            else if (curBuildConfigString.ToLower().Equals("release"))
+            {
+                buildConfigOption = BuildConfigEnum.RELEASE;
+            }
+            else
+            {
+                buildConfigOption = BuildConfigEnum.DEBUG;
+            }
+
+            buildConfigOption = (BuildConfigEnum)EditorGUILayout.EnumPopup(GUIHorizSpacer + "Build Configuration", buildConfigOption);
+
+            string newBuildConfig = buildConfigOption.ToString();
+
+            if (newBuildConfig != curBuildConfigString)
             {
                 BuildDeployPrefs.BuildConfig = newBuildConfig;
-                curBuildConfig = newBuildConfig;
+                curBuildConfigString = newBuildConfig;
             }
 
             // Build APPX button
@@ -185,6 +363,7 @@ namespace HoloToolkit.Unity
                 EditorGUIUtility.labelWidth = 50;
                 bool curForceRebuildAppx = BuildDeployPrefs.ForceRebuild;
                 bool newForceRebuildAppx = EditorGUILayout.Toggle("Rebuild", curForceRebuildAppx);
+
                 if (newForceRebuildAppx != curForceRebuildAppx)
                 {
                     BuildDeployPrefs.ForceRebuild = newForceRebuildAppx;
@@ -195,7 +374,9 @@ namespace HoloToolkit.Unity
                 EditorGUIUtility.labelWidth = 110;
                 bool curIncrementVersion = BuildDeployPrefs.IncrementBuildVersion;
                 bool newIncrementVersion = EditorGUILayout.Toggle("Increment version", curIncrementVersion);
-                if (newIncrementVersion != curIncrementVersion) {
+
+                if (newIncrementVersion != curIncrementVersion)
+                {
                     BuildDeployPrefs.IncrementBuildVersion = newIncrementVersion;
                     curIncrementVersion = newIncrementVersion;
                 }
@@ -205,12 +386,34 @@ namespace HoloToolkit.Unity
 
                 // Build APPX
                 GUI.enabled = ShouldBuildAppxBeEnabled;
+
                 if (GUILayout.Button("Build APPX from SLN", GUILayout.Width(buttonWidth_Half)))
                 {
-                    BuildDeployTools.BuildAppxFromSolution(appName, curMSBuildVer, curForceRebuildAppx, curBuildConfig, curBuildDirectory, curIncrementVersion);
+                    // Open SLN
+                    string slnFilename = Path.Combine(curBuildDirectory, PlayerSettings.productName + ".sln");
+
+                    if (File.Exists(slnFilename))
+                    {
+                        // Build APPX
+                        EditorApplication.delayCall += () =>
+                            BuildDeployTools.BuildAppxFromSLN(
+                                PlayerSettings.productName,
+                                curMSBuildVer,
+                                curForceRebuildAppx,
+                                curBuildConfigString,
+                                curBuildDirectory,
+                                curIncrementVersion);
+                    }
+                    else if (EditorUtility.DisplayDialog("Solution Not Found", "We couldn't find the solution. Would you like to Build it?", "Yes, Build", "No"))
+                    {
+                        // Build SLN then APPX
+                        EditorApplication.delayCall += () => BuildAll(install: false);
+                    }
                 }
+
                 GUI.enabled = true;
             }
+
             GUILayout.EndVertical();
             GUILayout.EndVertical();
 
@@ -236,10 +439,6 @@ namespace HoloToolkit.Unity
             }
             else
             {
-                var locatorIsSearching = XdeGuestLocator.IsSearching;
-                var locatorHasData = XdeGuestLocator.HasData;
-                var xdeGuestIpAddress = XdeGuestLocator.GuestIpAddress;
-
                 // Queue up a repaint if we're still busy, or we'll get stuck
                 // in a disabled state.
 
@@ -248,8 +447,7 @@ namespace HoloToolkit.Unity
                     Repaint();
                 }
 
-                var addressesToPresent = new List<string>();
-                addressesToPresent.Add("127.0.0.1");
+                var addressesToPresent = new List<string> { "127.0.0.1" };
 
                 if (!locatorIsSearching && locatorHasData)
                 {
@@ -257,6 +455,7 @@ namespace HoloToolkit.Unity
                 }
 
                 var previouslySavedAddress = addressesToPresent.IndexOf(curTargetIps);
+
                 if (previouslySavedAddress == -1)
                 {
                     previouslySavedAddress = 0;
@@ -295,80 +494,106 @@ namespace HoloToolkit.Unity
             bool curFullReinstall = BuildDeployPrefs.FullReinstall;
             bool newFullReinstall = EditorGUILayout.Toggle(
                 new GUIContent(GUIHorizSpacer + "Uninstall first", "Uninstall application before installing"), curFullReinstall);
-            if ((newUsername != curUsername) ||
-                (newPassword != curPassword) ||
-                (newFullReinstall != curFullReinstall))
+
+            if (newUsername != curUsername ||
+                newPassword != curPassword ||
+                newFullReinstall != curFullReinstall)
             {
                 BuildDeployPrefs.DeviceUser = newUsername;
                 BuildDeployPrefs.DevicePassword = newPassword;
                 BuildDeployPrefs.FullReinstall = newFullReinstall;
-
-                curUsername = newUsername;
-                curPassword = newPassword;
-                curFullReinstall = newFullReinstall;
             }
 
             // Build list (with install buttons)
-            if (this.builds.Count == 0)
+            if (builds.Count == 0)
             {
                 GUILayout.Label(GUIHorizSpacer + "*** No builds found in build directory", EditorStyles.boldLabel);
             }
             else
             {
-                foreach (var fullBuildLocation in this.builds)
+                GUILayout.BeginVertical();
+                scrollPosition = GUILayout.BeginScrollView(scrollPosition, GUILayout.Width(buttonWidth_Full), GUILayout.Height(128));
+
+                foreach (var fullBuildLocation in builds)
                 {
-                    int lastBackslashIndex = fullBuildLocation.LastIndexOf("\\");
+                    int lastBackslashIndex = fullBuildLocation.LastIndexOf("\\", StringComparison.Ordinal);
 
                     var directoryDate = Directory.GetLastWriteTime(fullBuildLocation).ToString("yyyy/MM/dd HH:mm:ss");
                     string packageName = fullBuildLocation.Substring(lastBackslashIndex + 1);
 
                     EditorGUILayout.BeginHorizontal();
                     GUILayout.Space(GUISectionOffset + 15);
+
+                    GUI.enabled = (!locatorIsSearching && locatorHasData || HoloLensUsbConnected);
                     if (GUILayout.Button("Install", GUILayout.Width(120.0f)))
                     {
                         string thisBuildLocation = fullBuildLocation;
-                        string[] IPlist = ParseIPList(curTargetIps);
+                        string[] ipList = ParseIPList(curTargetIps);
                         EditorApplication.delayCall += () =>
                         {
-                            InstallAppOnDevicesList(thisBuildLocation, curFullReinstall, IPlist);
+                            InstallAppOnDevicesList(thisBuildLocation, ipList);
                         };
                     }
+
+                    GUI.enabled = true;
+
                     GUILayout.Space(5);
                     GUILayout.Label(packageName + " (" + directoryDate + ")");
                     EditorGUILayout.EndHorizontal();
                 }
+                GUILayout.EndScrollView();
+                GUILayout.EndVertical();
+
                 EditorGUILayout.Separator();
             }
-            GUILayout.EndVertical();
 
+            GUILayout.EndVertical();
             GUILayout.Space(GUISectionOffset);
 
             // Utilities section
             GUILayout.BeginVertical();
             GUILayout.Label("Utilities");
 
+            // Open AppX packages location
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                GUI.enabled = builds.Count > 0;
+
+                GUILayout.FlexibleSpace();
+
+                if (GUILayout.Button("Open APPX Packages Location", GUILayout.Width(buttonWidth_Full)))
+                {
+                    Process.Start("explorer.exe", "/open," + Path.GetFullPath(curBuildDirectory + "/" + PlayerSettings.productName + "/AppPackages"));
+                }
+
+                GUI.enabled = true;
+            }
+
             // Open web portal
             using (new EditorGUILayout.HorizontalScope())
             {
-                GUI.enabled = ShouldWebPortalBeEnabled;
+                GUI.enabled = ShouldWebPortalBeEnabled && (!locatorIsSearching && locatorHasData || HoloLensUsbConnected);
                 GUILayout.FlexibleSpace();
+
                 if (GUILayout.Button("Open Device Portal", GUILayout.Width(buttonWidth_Full)))
                 {
                     OpenWebPortalForIPs(curTargetIps);
                 }
+
                 GUI.enabled = true;
             }
 
             // Launch app..
             using (new EditorGUILayout.HorizontalScope())
             {
-                GUI.enabled = ShouldLaunchAppBeEnabled;
+                GUI.enabled = ShouldLaunchAppBeEnabled && (!locatorIsSearching && locatorHasData || HoloLensUsbConnected);
                 GUILayout.FlexibleSpace();
+
                 if (GUILayout.Button("Launch Application", GUILayout.Width(buttonWidth_Full)))
                 {
                     // If already running, kill it (button is a toggle)
-                    if (IsAppRunning_FirstIPCheck(appName, curTargetIps))
-                    { 
+                    if (IsAppRunning_FirstIPCheck(PlayerSettings.productName, curTargetIps))
+                    {
                         KillAppOnIPs(curTargetIps);
                     }
                     else
@@ -376,40 +601,46 @@ namespace HoloToolkit.Unity
                         LaunchAppOnIPs(curTargetIps);
                     }
                 }
+
                 GUI.enabled = true;
             }
 
             // Log file
             using (new EditorGUILayout.HorizontalScope())
             {
-                GUI.enabled = ShouldLogViewBeEnabled;
+                GUI.enabled = ShouldLogViewBeEnabled && (!locatorIsSearching && locatorHasData || HoloLensUsbConnected);
                 GUILayout.FlexibleSpace();
+
                 if (GUILayout.Button("View Log File", GUILayout.Width(buttonWidth_Full)))
                 {
                     OpenLogFileForIPs(curTargetIps);
                 }
+
                 GUI.enabled = true;
             }
 
             // Uninstall...
             using (new EditorGUILayout.HorizontalScope())
             {
-                GUI.enabled = ShouldLogViewBeEnabled;
+                GUI.enabled = ShouldLogViewBeEnabled && (!locatorIsSearching && locatorHasData || HoloLensUsbConnected);
                 GUILayout.FlexibleSpace();
+
                 if (GUILayout.Button("Uninstall Application", GUILayout.Width(buttonWidth_Full)))
                 {
-                    string[] IPlist = ParseIPList(curTargetIps);
                     EditorApplication.delayCall += () =>
                     {
-                        UninstallAppOnDevicesList(IPlist);
+                        UninstallAppOnDevicesList(ParseIPList(curTargetIps));
                     };
                 }
+
                 GUI.enabled = true;
             }
+
+            //GUILayout.EndScrollView();
             GUILayout.EndVertical();
         }
 
-        void BuildAndRun(string appName)
+        private void BuildAll(bool install = true)
         {
             // First build SLN
             if (!BuildDeployTools.BuildSLN(BuildDeployPrefs.BuildDirectory, false))
@@ -418,21 +649,25 @@ namespace HoloToolkit.Unity
             }
 
             // Next, APPX
-            if (!BuildDeployTools.BuildAppxFromSolution(
-                appName, 
-                BuildDeployPrefs.MsBuildVersion, 
-                BuildDeployPrefs.ForceRebuild, 
-                BuildDeployPrefs.BuildConfig, 
+            if (!BuildDeployTools.BuildAppxFromSLN(
+                PlayerSettings.productName,
+                BuildDeployPrefs.MsBuildVersion,
+                BuildDeployPrefs.ForceRebuild,
+                BuildDeployPrefs.BuildConfig,
                 BuildDeployPrefs.BuildDirectory,
-                BuildDeployPrefs.IncrementBuildVersion))
+                BuildDeployPrefs.IncrementBuildVersion,
+                showConfDlg: !install))
             {
                 return;
             }
 
             // Next, Install
-            string fullBuildLocation = CalcMostRecentBuild();
-            string[] IPlist = ParseIPList(BuildDeployPrefs.TargetIPs);
-            InstallAppOnDevicesList(fullBuildLocation, BuildDeployPrefs.FullReinstall, IPlist);
+            if (install)
+            {
+                string fullBuildLocation = CalcMostRecentBuild();
+                string[] ipList = ParseIPList(BuildDeployPrefs.TargetIPs);
+                InstallAppOnDevicesList(fullBuildLocation, ipList);
+            }
         }
 
         private string CalcMostRecentBuild()
@@ -440,15 +675,18 @@ namespace HoloToolkit.Unity
             UpdateBuilds();
             DateTime mostRecent = DateTime.MinValue;
             string mostRecentBuild = "";
-            foreach (var fullBuildLocation in this.builds)
+
+            foreach (var fullBuildLocation in builds)
             {
                 DateTime directoryDate = Directory.GetLastWriteTime(fullBuildLocation);
+
                 if (directoryDate > mostRecent)
                 {
                     mostRecentBuild = fullBuildLocation;
                     mostRecent = directoryDate;
                 }
             }
+
             return mostRecentBuild;
         }
 
@@ -456,32 +694,35 @@ namespace HoloToolkit.Unity
         {
             // Find the manifest
             string[] manifests = Directory.GetFiles(BuildDeployPrefs.AbsoluteBuildDirectory, "Package.appxmanifest", SearchOption.AllDirectories);
+
             if (manifests.Length == 0)
             {
                 Debug.LogError("Unable to find manifest file for build (in path - " + BuildDeployPrefs.AbsoluteBuildDirectory + ")");
                 return "";
             }
+
             string manifest = manifests[0];
 
             // Parse it
-            using (XmlTextReader reader = new XmlTextReader(manifest))
+            using (var reader = new XmlTextReader(manifest))
             {
                 while (reader.Read())
                 {
                     switch (reader.NodeType)
-                    { 
-                    case XmlNodeType.Element:
-                        if (reader.Name.Equals("identity", StringComparison.OrdinalIgnoreCase))
-                        {
-                            while (reader.MoveToNextAttribute())
+                    {
+                        case XmlNodeType.Element:
+                            if (reader.Name.Equals("identity", StringComparison.OrdinalIgnoreCase))
                             {
-                                if (reader.Name.Equals("name", StringComparison.OrdinalIgnoreCase))
+                                while (reader.MoveToNextAttribute())
                                 {
-                                    return reader.Value;
+                                    if (reader.Name.Equals("name", StringComparison.OrdinalIgnoreCase))
+                                    {
+                                        return reader.Value;
+                                    }
                                 }
                             }
-                        }
-                        break;
+
+                            break;
                     }
                 }
             }
@@ -490,9 +731,10 @@ namespace HoloToolkit.Unity
             return "";
         }
 
-        private void InstallAppOnDevicesList(string buildPath, bool uninstallBeforeInstall, string[] targetList)
+        private void InstallAppOnDevicesList(string buildPath, string[] targetList)
         {
             string packageFamilyName = CalcPackageFamilyName();
+
             if (string.IsNullOrEmpty(packageFamilyName))
             {
                 return;
@@ -503,20 +745,22 @@ namespace HoloToolkit.Unity
                 try
                 {
                     bool completedUninstall = false;
-                    string IP = FinalizeIP(targetList[i]);
+                    string ip = FinalizeIP(targetList[i]);
                     if (BuildDeployPrefs.FullReinstall &&
-                        BuildDeployPortal.IsAppInstalled(packageFamilyName, new BuildDeployPortal.ConnectInfo(IP, BuildDeployPrefs.DeviceUser, BuildDeployPrefs.DevicePassword)))
+                        BuildDeployPortal.IsAppInstalled(packageFamilyName, new BuildDeployPortal.ConnectInfo(ip, BuildDeployPrefs.DeviceUser, BuildDeployPrefs.DevicePassword)))
                     {
-                        EditorUtility.DisplayProgressBar("Installing on devices", "Uninstall (" + IP + ")", (float)i / (float)targetList.Length);
-                        if (!UninstallApp(packageFamilyName, IP))
+                        EditorUtility.DisplayProgressBar("Installing on devices", "Uninstall (" + ip + ")", i / (float)targetList.Length);
+                        if (!UninstallApp(packageFamilyName, ip))
                         {
-                            Debug.LogError("Uninstall failed - skipping install (" + IP + ")");
+                            Debug.LogError("Uninstall failed - skipping install (" + ip + ")");
                             continue;
                         }
+
                         completedUninstall = true;
                     }
-                    EditorUtility.DisplayProgressBar("Installing on devices", "Install (" + IP + ")", (float)(i + (completedUninstall ? 0.5f : 0.0f)) / (float)targetList.Length);
-                    InstallApp(buildPath, packageFamilyName, IP);
+
+                    EditorUtility.DisplayProgressBar("Installing on devices", "Install (" + ip + ")", (i + (completedUninstall ? 0.5f : 0.0f)) / targetList.Length);
+                    InstallApp(buildPath, ip);
                 }
                 catch (Exception ex)
                 {
@@ -526,11 +770,12 @@ namespace HoloToolkit.Unity
             EditorUtility.ClearProgressBar();
         }
 
-        private bool InstallApp(string buildPath, string appName, string targetDevice)
+        private bool InstallApp(string buildPath, string targetDevice)
         {
             // Get the appx path
-            FileInfo[] files = (new DirectoryInfo(buildPath)).GetFiles("*.appx");
-            files = (files.Length == 0) ? (new DirectoryInfo(buildPath)).GetFiles("*.appxbundle") : files;
+            FileInfo[] files = new DirectoryInfo(buildPath).GetFiles("*.appx");
+            files = files.Length == 0 ? new DirectoryInfo(buildPath).GetFiles("*.appxbundle") : files;
+
             if (files.Length == 0)
             {
                 Debug.LogError("No APPX found in folder build folder (" + buildPath + ")");
@@ -548,6 +793,7 @@ namespace HoloToolkit.Unity
         private void UninstallAppOnDevicesList(string[] targetList)
         {
             string packageFamilyName = CalcPackageFamilyName();
+
             if (string.IsNullOrEmpty(packageFamilyName))
             {
                 return;
@@ -557,15 +803,16 @@ namespace HoloToolkit.Unity
             {
                 for (int i = 0; i < targetList.Length; i++)
                 {
-                    string IP = FinalizeIP(targetList[i]);
-                    EditorUtility.DisplayProgressBar("Uninstalling application", "Uninstall (" + IP + ")", (float)i / (float)targetList.Length);
-                    UninstallApp(packageFamilyName, IP);
+                    string ip = FinalizeIP(targetList[i]);
+                    EditorUtility.DisplayProgressBar("Uninstalling application", "Uninstall (" + ip + ")", i / (float)targetList.Length);
+                    UninstallApp(packageFamilyName, ip);
                 }
             }
             catch (Exception ex)
             {
                 Debug.LogError(ex.ToString());
             }
+
             EditorUtility.ClearProgressBar();
         }
 
@@ -581,11 +828,11 @@ namespace HoloToolkit.Unity
 
         private void UpdateBuilds()
         {
-            this.builds.Clear();
+            builds.Clear();
 
             try
             {
-                List<string> appPackageDirectories = new List<string>();
+                var appPackageDirectories = new List<string>();
                 string[] buildList = Directory.GetDirectories(BuildDeployPrefs.AbsoluteBuildDirectory);
                 foreach (string appBuild in buildList)
                 {
@@ -595,125 +842,145 @@ namespace HoloToolkit.Unity
                         appPackageDirectories.AddRange(Directory.GetDirectories(appPackageDirectory));
                     }
                 }
+
                 IEnumerable<string> selectedDirectories =
                     from string directory in appPackageDirectories
                     orderby Directory.GetLastWriteTime(directory) descending
                     select Path.GetFullPath(directory);
-                this.builds.AddRange(selectedDirectories);
+                builds.AddRange(selectedDirectories);
             }
             catch (DirectoryNotFoundException)
             {
+                // unused
             }
 
             timeLastUpdatedBuilds = Time.realtimeSinceStartup;
         }
 
-        void Update()
+        private void Update()
         {
-            if ((Time.realtimeSinceStartup - timeLastUpdatedBuilds) > UpdateBuildsPeriod)
+            if (Time.realtimeSinceStartup - timeLastUpdatedBuilds > UpdateBuildsPeriod)
             {
                 UpdateBuilds();
             }
         }
 
-        public static string[] ParseIPList(string IPs)
+        public static string[] ParseIPList(string targetIPs)
         {
-            string[] IPlist = { };
+            string[] ipList = { };
 
-            if (IPs == null || IPs == "")
-                return IPlist;
+            if (string.IsNullOrEmpty(targetIPs))
+            {
+                return ipList;
+            }
 
             string[] separators = { ";", " " };
-            IPlist = IPs.Split(separators, System.StringSplitOptions.RemoveEmptyEntries);
-            return IPlist;
+            ipList = targetIPs.Split(separators, StringSplitOptions.RemoveEmptyEntries);
+            return ipList;
         }
 
-        static string FinalizeIP(string ip)
+        private static string FinalizeIP(string ip)
         {
             // If it's local, add the port
             if (ip == "127.0.0.1")
             {
                 ip += ":10080";
             }
+
             return ip;
         }
 
-        public static void OpenWebPortalForIPs(string IPs)
+        public static void OpenWebPortalForIPs(string targetIPs)
         {
-            string[] ipList = ParseIPList(IPs);
+            string[] ipList = ParseIPList(targetIPs);
+
             for (int i = 0; i < ipList.Length; i++)
             {
                 string url = string.Format("http://{0}", FinalizeIP(ipList[i]));
 
                 // Run the process
-                System.Diagnostics.Process.Start(url);
+                Process.Start(url);
             }
         }
 
-        bool IsAppRunning_FirstIPCheck(string appName, string targetIPs)
+        private bool IsAppRunning_FirstIPCheck(string appName, string targetIPs)
         {
             // Just pick the first one and use it...
-            string[] IPlist = ParseIPList(targetIPs);
-            if (IPlist.Length > 0)
+            string[] ipList = ParseIPList(targetIPs);
+
+            if (ipList.Length > 0)
             {
-                string targetIP = FinalizeIP(IPlist[0]);
+                string targetIP = FinalizeIP(ipList[0]);
                 return BuildDeployPortal.IsAppRunning(
-                    appName, new BuildDeployPortal.ConnectInfo(targetIP, BuildDeployPrefs.DeviceUser, BuildDeployPrefs.DevicePassword));
+                    appName,
+                    new BuildDeployPortal.ConnectInfo(targetIP, BuildDeployPrefs.DeviceUser, BuildDeployPrefs.DevicePassword));
             }
+
             return false;
         }
 
-        void LaunchAppOnIPs(string targetIPs)
+        private void LaunchAppOnIPs(string targetIPs)
         {
             string packageFamilyName = CalcPackageFamilyName();
+
             if (string.IsNullOrEmpty(packageFamilyName))
             {
                 return;
             }
 
-            string[] IPlist = ParseIPList(targetIPs);
-            for (int i = 0; i < IPlist.Length; i++)
+            string[] ipList = ParseIPList(targetIPs);
+
+            for (int i = 0; i < ipList.Length; i++)
             {
-                string targetIP = FinalizeIP(IPlist[i]);
+                string targetIP = FinalizeIP(ipList[i]);
                 Debug.Log("Launch app on: " + targetIP);
                 BuildDeployPortal.LaunchApp(
-                    packageFamilyName, new BuildDeployPortal.ConnectInfo(targetIP, BuildDeployPrefs.DeviceUser, BuildDeployPrefs.DevicePassword));
+                    packageFamilyName,
+                    new BuildDeployPortal.ConnectInfo(targetIP, BuildDeployPrefs.DeviceUser, BuildDeployPrefs.DevicePassword));
             }
         }
 
-        void KillAppOnIPs(string targetIPs)
+        private void KillAppOnIPs(string targetIPs)
         {
             string packageFamilyName = CalcPackageFamilyName();
+
             if (string.IsNullOrEmpty(packageFamilyName))
             {
                 return;
             }
 
-            string[] IPlist = ParseIPList(targetIPs);
-            for (int i = 0; i < IPlist.Length; i++)
+            string[] ipList = ParseIPList(targetIPs);
+
+            for (int i = 0; i < ipList.Length; i++)
             {
-                string targetIP = FinalizeIP(IPlist[i]);
+                string targetIP = FinalizeIP(ipList[i]);
                 Debug.Log("Kill app on: " + targetIP);
                 BuildDeployPortal.KillApp(
-                    packageFamilyName, new BuildDeployPortal.ConnectInfo(targetIP, BuildDeployPrefs.DeviceUser, BuildDeployPrefs.DevicePassword));
+                    packageFamilyName,
+                    new BuildDeployPortal.ConnectInfo(targetIP, BuildDeployPrefs.DeviceUser, BuildDeployPrefs.DevicePassword));
             }
         }
 
-        public void OpenLogFileForIPs(string IPs)
+        public void OpenLogFileForIPs(string targetIPs)
         {
             string packageFamilyName = CalcPackageFamilyName();
+
             if (string.IsNullOrEmpty(packageFamilyName))
             {
                 return;
             }
 
-            string[] ipList = ParseIPList(IPs);
+            string[] ipList = ParseIPList(targetIPs);
+
             for (int i = 0; i < ipList.Length; i++)
             {
                 // Use the Device Portal REST API
                 BuildDeployPortal.DeviceLogFile_View(
-                    packageFamilyName, new BuildDeployPortal.ConnectInfo(FinalizeIP(ipList[i]), BuildDeployPrefs.DeviceUser, BuildDeployPrefs.DevicePassword));
+                    packageFamilyName,
+                    new BuildDeployPortal.ConnectInfo(FinalizeIP(ipList[i]), BuildDeployPrefs.DeviceUser, BuildDeployPrefs.DevicePassword));
             }
         }
+
+        #endregion // Methods
     }
 }

--- a/Assets/HoloToolkit/Build/Editor/BuildInfo.cs
+++ b/Assets/HoloToolkit/Build/Editor/BuildInfo.cs
@@ -1,0 +1,100 @@
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace HoloToolkit.Unity
+{
+    public class BuildInfo
+    {
+        public string OutputDirectory { get; set; }
+
+        public IEnumerable<string> Scenes { get; set; }
+
+        public IEnumerable<CopyDirectoryInfo> CopyDirectories { get; set; }
+
+        public Action<BuildInfo> PreBuildAction { get; set; }
+
+        public Action<BuildInfo, string> PostBuildAction { get; set; }
+
+        public BuildOptions BuildOptions { get; set; }
+
+        public BuildTarget BuildTarget { get; set; }
+
+        public WSASDK? WSASdk { get; set; }
+
+        public string WSAUwpSdk { get; set; }
+
+        public WSAUWPBuildType? WSAUWPBuildType { get; set; }
+
+        public bool? WSAGenerateReferenceProjects { get; set; }
+
+        public ColorSpace? ColorSpace { get; set; }
+
+        public bool IsCommandLine { get; set; }
+
+        public string BuildSymbols { get; private set; }
+
+        public BuildInfo()
+        {
+            BuildSymbols = string.Empty;
+        }
+
+        public void AppendSymbols(params string[] symbol)
+        {
+            AppendSymbols((IEnumerable<string>)symbol);
+        }
+
+        public void AppendSymbols(IEnumerable<string> symbols)
+        {
+            string[] toAdd = symbols.Except(BuildSymbols.Split(';'))
+                .Where(sym => !string.IsNullOrEmpty(sym)).ToArray();
+
+            if (!toAdd.Any())
+            {
+                return;
+            }
+
+            if (!string.IsNullOrEmpty(BuildSymbols))
+            {
+                BuildSymbols += ";";
+            }
+
+            BuildSymbols += string.Join(";", toAdd);
+        }
+
+        public bool HasAnySymbols(params string[] symbols)
+        {
+            return BuildSymbols.Split(';').Intersect(symbols).Any();
+        }
+
+        public bool HasConfigurationSymbol()
+        {
+            return HasAnySymbols(
+                BuildSLNUtilities.BuildSymbolDebug,
+                BuildSLNUtilities.BuildSymbolRelease,
+                BuildSLNUtilities.BuildSymbolMaster);
+        }
+
+        public static IEnumerable<string> RemoveConfigurationSymbols(string symbolstring)
+        {
+            return symbolstring.Split(';').Except(new[]
+            {
+                BuildSLNUtilities.BuildSymbolDebug,
+                BuildSLNUtilities.BuildSymbolRelease,
+                BuildSLNUtilities.BuildSymbolMaster
+            });
+        }
+
+        public bool HasAnySymbols(IEnumerable<string> symbols)
+        {
+            return BuildSymbols.Split(';').Intersect(symbols).Any();
+        }
+    }
+}

--- a/Assets/HoloToolkit/Build/Editor/BuildInfo.cs.meta
+++ b/Assets/HoloToolkit/Build/Editor/BuildInfo.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8641cc4d0d7648aca3b48f7d2302a094
+timeCreated: 1497140920

--- a/Assets/HoloToolkit/Build/Editor/BuildSLNUtilities.cs
+++ b/Assets/HoloToolkit/Build/Editor/BuildSLNUtilities.cs
@@ -20,105 +20,6 @@ namespace HoloToolkit.Unity
     /// </summary>
     public static class BuildSLNUtilities
     {
-        public class CopyDirectoryInfo
-        {
-            public string Source { get; set; }
-            public string Destination { get; set; }
-            public string Filter { get; set; }
-            public bool Recursive { get; set; }
-
-            public CopyDirectoryInfo()
-            {
-                Source = null;
-                Destination = null;
-                Filter = "*";
-                Recursive = false;
-            }
-        }
-
-        public class BuildInfo
-        {
-            public string OutputDirectory { get; set; }
-            public IEnumerable<string> Scenes { get; set; }
-            public IEnumerable<CopyDirectoryInfo> CopyDirectories { get; set; }
-
-            public Action<BuildInfo> PreBuildAction { get; set; }
-            public Action<BuildInfo, string> PostBuildAction { get; set; }
-
-            public BuildOptions BuildOptions { get; set; }
-
-            // EditorUserBuildSettings
-            public BuildTarget BuildTarget { get; set; }
-
-            public WSASDK? WSASdk { get; set; }
-
-            public string WsaUwpSdk { get; set; }
-
-            public WSAUWPBuildType? WSAUWPBuildType { get; set; }
-
-            public Boolean? WSAGenerateReferenceProjects { get; set; }
-
-            public ColorSpace? ColorSpace { get; set; }
-            public bool IsCommandLine { get; set; }
-            public string BuildSymbols { get; private set; }
-
-            public BuildInfo()
-            {
-                BuildSymbols = string.Empty;
-            }
-
-            public void AppendSymbols(params string[] symbol)
-            {
-                this.AppendSymbols((IEnumerable<string>)symbol);
-            }
-
-            public void AppendSymbols(IEnumerable<string> symbols)
-            {
-                string[] toAdd = symbols.Except(this.BuildSymbols.Split(';'))
-                    .Where(sym => !string.IsNullOrEmpty(sym)).ToArray();
-
-                if (!toAdd.Any())
-                {
-                    return;
-                }
-
-                if (!String.IsNullOrEmpty(this.BuildSymbols))
-                {
-                    this.BuildSymbols += ";";
-                }
-
-                this.BuildSymbols += String.Join(";", toAdd);
-            }
-
-            public bool HasAnySymbols(params string[] symbols)
-            {
-                return this.BuildSymbols.Split(';').Intersect(symbols).Any();
-            }
-
-            public bool HasConfigurationSymbol()
-            {
-                return HasAnySymbols(
-                    BuildSLNUtilities.BuildSymbolDebug,
-                    BuildSLNUtilities.BuildSymbolRelease,
-                    BuildSLNUtilities.BuildSymbolMaster);
-            }
-
-            public static IEnumerable<string> RemoveConfigurationSymbols(string symbolstring)
-            {
-                return symbolstring.Split(';').Except(new[]
-                {
-                    BuildSLNUtilities.BuildSymbolDebug,
-                    BuildSLNUtilities.BuildSymbolRelease,
-                    BuildSLNUtilities.BuildSymbolMaster
-                });
-            }
-
-            public bool HasAnySymbols(IEnumerable<string> symbols)
-            {
-                return this.BuildSymbols.Split(';').Intersect(symbols).Any();
-            }
-        }
-
         /// <summary>
         /// A method capable of configuring <see cref="BuildInfo"/> settings.
         /// </summary>
@@ -138,11 +39,9 @@ namespace HoloToolkit.Unity
         /// <seealso cref="OverrideBuildDefaults"/>
         public static void RaiseOverrideBuildDefaults(ref BuildInfo toConfigure)
         {
-            var handlers = OverrideBuildDefaults;
-
-            if (handlers != null)
+            if (OverrideBuildDefaults != null)
             {
-                handlers(ref toConfigure);
+                OverrideBuildDefaults(ref toConfigure);
             }
         }
 
@@ -181,16 +80,16 @@ namespace HoloToolkit.Unity
             {
                 if (!buildInfo.HasConfigurationSymbol())
                 {
-                    buildInfo.AppendSymbols(BuildSLNUtilities.BuildSymbolDebug);
+                    buildInfo.AppendSymbols(BuildSymbolDebug);
                 }
             }
 
-            if (buildInfo.HasAnySymbols(BuildSLNUtilities.BuildSymbolDebug))
+            if (buildInfo.HasAnySymbols(BuildSymbolDebug))
             {
                 buildInfo.BuildOptions |= BuildOptions.Development | BuildOptions.AllowDebugging;
             }
 
-            if (buildInfo.HasAnySymbols(BuildSLNUtilities.BuildSymbolRelease))
+            if (buildInfo.HasAnySymbols(BuildSymbolRelease))
             {
                 //Unity automatically adds the DEBUG symbol if the BuildOptions.Development flag is
                 //specified. In order to have debug symbols and the RELEASE symbole we have to
@@ -198,22 +97,20 @@ namespace HoloToolkit.Unity
                 buildInfo.AppendSymbols("DEVELOPMENT_BUILD");
             }
 
-            var oldBuildTarget = EditorUserBuildSettings.activeBuildTarget;
-            EditorUserBuildSettings.SwitchActiveBuildTarget(buildInfo.BuildTarget);
+            BuildTarget oldBuildTarget = EditorUserBuildSettings.activeBuildTarget;
+            BuildTargetGroup oldBuildTargetGroup = GetGroup(oldBuildTarget);
 
-            var oldWSASDK = EditorUserBuildSettings.wsaSDK;
+            EditorUserBuildSettings.SwitchActiveBuildTarget(buildTargetGroup, buildInfo.BuildTarget);
+
+            WSASDK oldWSASDK = EditorUserBuildSettings.wsaSDK;
             if (buildInfo.WSASdk.HasValue)
             {
                 EditorUserBuildSettings.wsaSDK = buildInfo.WSASdk.Value;
             }
 
-            string oldWsaUwpSdk = null;
             WSAUWPBuildType? oldWSAUWPBuildType = null;
             if (EditorUserBuildSettings.wsaSDK == WSASDK.UWP)
             {
-                oldWsaUwpSdk = EditorUserBuildSettings.wsaUWPSDK;
-                EditorUserBuildSettings.wsaUWPSDK = buildInfo.WsaUwpSdk;
-
                 oldWSAUWPBuildType = EditorUserBuildSettings.wsaUWPBuildType;
                 if (buildInfo.WSAUWPBuildType.HasValue)
                 {
@@ -278,16 +175,16 @@ namespace HoloToolkit.Unity
                 PlayerSettings.colorSpace = oldColorSpace;
                 PlayerSettings.SetScriptingDefineSymbolsForGroup(buildTargetGroup, oldBuildSymbols);
 
-                if (EditorUserBuildSettings.wsaSDK == WSASDK.UWP)
+                if (oldWSAUWPBuildType.HasValue)
                 {
-                    EditorUserBuildSettings.wsaUWPSDK = oldWsaUwpSdk;
                     EditorUserBuildSettings.wsaUWPBuildType = oldWSAUWPBuildType.Value;
                 }
+
                 EditorUserBuildSettings.wsaSDK = oldWSASDK;
 
                 EditorUserBuildSettings.wsaGenerateReferenceProjects = oldWSAGenerateReferenceProjects;
 
-                EditorUserBuildSettings.SwitchActiveBuildTarget(oldBuildTarget);
+                EditorUserBuildSettings.SwitchActiveBuildTarget(oldBuildTargetGroup, oldBuildTarget);
             }
         }
 
@@ -300,54 +197,48 @@ namespace HoloToolkit.Unity
                 return;
             }
 
-
             IEnumerable<Version> uwpSdksAvailable;
             try
             {
                 // In order to get the same list of SDKs that the Unity build settings "UWP SDK" box has, we call into an
                 // internal Unity function.  If Unity changes how its internals work, we'll need to update this code.
+                Type uwpReferencesType = typeof(Editor).Assembly.GetType("UnityEditor.Scripting.Compilers.UWPReferences", throwOnError: false);
 
-                Type uwpReferencesType = typeof(UnityEditor.Editor).Assembly
-                    .GetType("UnityEditor.Scripting.Compilers.UWPReferences", throwOnError: false);
-
-                MethodInfo uwpReferencesMethod = (uwpReferencesType == null)
+                MethodInfo uwpReferencesMethod = uwpReferencesType == null
                     ? null
                     : uwpReferencesType.GetMethod("GetInstalledSDKVersions");
 
-                uwpSdksAvailable = (uwpReferencesMethod == null)
+                uwpSdksAvailable = uwpReferencesMethod == null
                     ? null
-                    : (uwpReferencesMethod.Invoke(obj: null, parameters: null) as IEnumerable<Version>);
+                    : uwpReferencesMethod.Invoke(null, null) as IEnumerable<Version>;
             }
             catch
             {
                 uwpSdksAvailable = null;
             }
 
-
             if (uwpSdksAvailable == null)
             {
                 Debug.LogWarningFormat("Couldn't verify that UWP SDK \"{0}\" is installed. You better make sure it's installed"
-                        + " and available in your Unity Build settings menu, or you may get unexpected build breaks or runtime"
-                        + " behavior.",
+                                    + " and available in your Unity Build settings menu, or you may get unexpected build breaks or runtime"
+                                    + " behavior.",
                     wsaUwpSdk
-                    );
+                );
             }
             else if (!uwpSdksAvailable.Select(version => version.ToString()).Contains(wsaUwpSdk))
             {
                 throw new Exception(string.Format("UWP SDK \"{0}\" is not installed. Please install it and try building again. If"
-                        + " you really want to build without that SDK, build directly from Unity's Build settings menu instead.",
+                                               + " you really want to build without that SDK, build directly from Unity's Build settings menu instead.",
                     wsaUwpSdk
-                    ));
+                ));
             }
-            else
-            {
-                // The SDK is verified installed. All is right with the world!
-            }
+
+            // The SDK is verified installed. All is right with the world!
         }
 
         public static void ParseBuildCommandLine(ref BuildInfo buildInfo)
         {
-            string[] arguments = System.Environment.GetCommandLineArgs();
+            string[] arguments = Environment.GetCommandLineArgs();
 
             buildInfo.IsCommandLine = true;
 
@@ -364,18 +255,17 @@ namespace HoloToolkit.Unity
 
                     buildInfo.WSASdk = (WSASDK)Enum.Parse(typeof(WSASDK), wsaSdkArg);
                 }
-                else if (string.Equals(arguments[i], "-wsaUwpSdk", StringComparison.InvariantCultureIgnoreCase))
+                else if (string.Equals(arguments[i], "-usaUwpSdk", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    buildInfo.WsaUwpSdk = arguments[++i];
+                    buildInfo.WSAUwpSdk = arguments[++i];
                 }
                 else if (string.Equals(arguments[i], "-wsaUWPBuildType", StringComparison.InvariantCultureIgnoreCase))
                 {
-
                     buildInfo.WSAUWPBuildType = (WSAUWPBuildType)Enum.Parse(typeof(WSAUWPBuildType), arguments[++i]);
                 }
                 else if (string.Equals(arguments[i], "-wsaGenerateReferenceProjects", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    buildInfo.WSAGenerateReferenceProjects = Boolean.Parse(arguments[++i]);
+                    buildInfo.WSAGenerateReferenceProjects = bool.Parse(arguments[++i]);
                 }
                 else if (string.Equals(arguments[i], "-buildOutput", StringComparison.InvariantCultureIgnoreCase))
                 {
@@ -395,12 +285,23 @@ namespace HoloToolkit.Unity
 
         public static void PerformBuild_CommandLine()
         {
-            BuildInfo buildInfo = new BuildInfo()
+            var buildInfo = new BuildInfo
             {
-                Scenes = EditorBuildSettings.scenes.Where(scene => scene.enabled).Select(scene => scene.path), // Use scenes from the editor build settings.
+                // Use scenes from the editor build settings.
+                Scenes = EditorBuildSettings.scenes.Where(scene => scene.enabled).Select(scene => scene.path),
+
+                // Configure a post build action to throw appropreate error code.
+                PostBuildAction = (innerBuildInfo, buildError) =>
+                {
+                    if (!string.IsNullOrEmpty(buildError))
+                    {
+                        EditorApplication.Exit(1);
+                    }
+                }
             };
 
             RaiseOverrideBuildDefaults(ref buildInfo);
+
             ParseBuildCommandLine(ref buildInfo);
 
             PerformBuild(buildInfo);
@@ -411,7 +312,7 @@ namespace HoloToolkit.Unity
             Debug.Log(string.Format(CultureInfo.InvariantCulture, "Build: Using \"{0}\" as build description", filename));
 
             // Parse the XML file
-            XmlTextReader reader = new XmlTextReader(filename);
+            var reader = new XmlTextReader(filename);
 
             while (reader.Read())
             {
@@ -449,7 +350,7 @@ namespace HoloToolkit.Unity
 
         private static IEnumerable<string> ReadSceneList(XmlTextReader reader)
         {
-            List<string> result = new List<string>();
+            var result = new List<string>();
             while (reader.Read())
             {
                 switch (reader.NodeType)
@@ -480,7 +381,7 @@ namespace HoloToolkit.Unity
 
         private static IEnumerable<CopyDirectoryInfo> ReadCopyList(XmlTextReader reader)
         {
-            List<CopyDirectoryInfo> result = new List<CopyDirectoryInfo>();
+            var result = new List<CopyDirectoryInfo>();
             while (reader.Read())
             {
                 switch (reader.NodeType)
@@ -505,7 +406,7 @@ namespace HoloToolkit.Unity
                                 }
                                 else if (string.Equals(reader.Name, "Recursive", StringComparison.InvariantCultureIgnoreCase))
                                 {
-                                    recursive = System.Convert.ToBoolean(reader.Value);
+                                    recursive = Convert.ToBoolean(reader.Value);
                                 }
                                 else if (string.Equals(reader.Name, "Filter", StringComparison.InvariantCultureIgnoreCase))
                                 {
@@ -516,8 +417,8 @@ namespace HoloToolkit.Unity
                             if (source != null)
                             {
                                 // Either the file specifies the Destination as well, or else CopyDirectory will use Source for Destination
-                                CopyDirectoryInfo info = new CopyDirectoryInfo();
-                                info.Source = source;
+                                var info = new CopyDirectoryInfo { Source = source };
+
                                 if (dest != null)
                                 {
                                     info.Destination = dest;

--- a/Assets/HoloToolkit/Build/Editor/CertificatePasswordWindow.cs
+++ b/Assets/HoloToolkit/Build/Editor/CertificatePasswordWindow.cs
@@ -1,0 +1,118 @@
+﻿//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+//
+
+using System;
+using UnityEditor;
+using UnityEngine;
+
+namespace HoloToolkit.Unity
+{
+    public class CertificatePasswordWindow : EditorWindow
+    {
+        private static readonly GUILayoutOption LabelWidth = GUILayout.Width(110f);
+
+        private static readonly GUILayoutOption ButtonWidth = GUILayout.Width(110f);
+
+        private string path;
+
+        private string password;
+
+        private GUIContent message;
+
+        private GUIStyle messageStyle;
+
+        private string focus;
+
+        public static void Show(string path)
+        {
+            CertificatePasswordWindow[] array = (CertificatePasswordWindow[])Resources.FindObjectsOfTypeAll(typeof(CertificatePasswordWindow));
+            CertificatePasswordWindow certificatePasswordWindow = (array.Length <= 0) ? CreateInstance<CertificatePasswordWindow>() : array[0];
+            path = path.Replace("\\", "/");
+            certificatePasswordWindow.path = path.Substring(path.LastIndexOf("Assets/", StringComparison.Ordinal));
+            certificatePasswordWindow.password = string.Empty;
+            certificatePasswordWindow.message = GUIContent.none;
+            certificatePasswordWindow.messageStyle = new GUIStyle(GUI.skin.label);
+            certificatePasswordWindow.messageStyle.fontStyle = FontStyle.Italic;
+            certificatePasswordWindow.focus = "password";
+            if (array.Length > 0)
+            {
+                certificatePasswordWindow.Focus();
+            }
+            else
+            {
+                certificatePasswordWindow.titleContent = new GUIContent("Enter Windows Store Certificate Password");
+                certificatePasswordWindow.position = new Rect(100f, 100f, 350f, 90f);
+                certificatePasswordWindow.minSize = new Vector2(certificatePasswordWindow.position.width, certificatePasswordWindow.position.height);
+                certificatePasswordWindow.maxSize = certificatePasswordWindow.minSize;
+                certificatePasswordWindow.ShowUtility();
+            }
+        }
+
+        public void OnGUI()
+        {
+            Event current = Event.current;
+            bool flag = false;
+            bool flag2 = false;
+
+            if (current.type == EventType.KeyDown)
+            {
+                flag = (current.keyCode == KeyCode.Escape);
+                flag2 = (current.keyCode == KeyCode.Return || current.keyCode == KeyCode.KeypadEnter);
+            }
+
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                GUILayout.Space(10f);
+                using (new EditorGUILayout.VerticalScope())
+                {
+                    GUILayout.FlexibleSpace();
+                    using (new EditorGUILayout.HorizontalScope())
+                    {
+                        GUILayout.Label(new GUIContent("Password|Certificate password."), LabelWidth);
+                        GUI.SetNextControlName("password");
+                        password = GUILayout.PasswordField(password, '●');
+                    }
+                    GUILayout.Space(10f);
+                    using (new EditorGUILayout.HorizontalScope())
+                    {
+                        GUILayout.Label(message, messageStyle);
+                        GUILayout.FlexibleSpace();
+                        if (GUILayout.Button(new GUIContent("Ok"), ButtonWidth) || flag2)
+                        {
+                            message = GUIContent.none;
+                            try
+                            {
+                                if (PlayerSettings.WSA.SetCertificate(path, password))
+                                {
+                                    flag = true;
+                                }
+                                else
+                                {
+                                    message = new GUIContent("Invalid password.");
+                                }
+                            }
+                            catch (UnityException ex)
+                            {
+                                Debug.LogError(ex.Message);
+                            }
+                        }
+                    }
+                    GUILayout.FlexibleSpace();
+                }
+                GUILayout.Space(10f);
+            }
+
+            if (flag)
+            {
+                Close();
+            }
+            else if (focus != null)
+            {
+                EditorGUI.FocusTextInControl(focus);
+                focus = null;
+            }
+        }
+    }
+}

--- a/Assets/HoloToolkit/Build/Editor/CertificatePasswordWindow.cs.meta
+++ b/Assets/HoloToolkit/Build/Editor/CertificatePasswordWindow.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0ff5d5ee9ce34c18a0df4ea5495be19b
+timeCreated: 1497159260

--- a/Assets/HoloToolkit/Build/Editor/CopyDirectoryInfo.cs
+++ b/Assets/HoloToolkit/Build/Editor/CopyDirectoryInfo.cs
@@ -1,0 +1,23 @@
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+//
+
+namespace HoloToolkit.Unity
+{
+    public class CopyDirectoryInfo
+    {
+        public string Source { get; set; }
+        public string Destination { get; set; }
+        public string Filter { get; set; }
+        public bool Recursive { get; set; }
+
+        public CopyDirectoryInfo()
+        {
+            Source = null;
+            Destination = null;
+            Filter = "*";
+            Recursive = false;
+        }
+    }
+}

--- a/Assets/HoloToolkit/Build/Editor/CopyDirectoryInfo.cs.meta
+++ b/Assets/HoloToolkit/Build/Editor/CopyDirectoryInfo.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 23511800bce94604830cfd49251a3746
+timeCreated: 1497140939

--- a/Assets/HoloToolkit/Build/Editor/HoloToolkitCommands.cs
+++ b/Assets/HoloToolkit/Build/Editor/HoloToolkitCommands.cs
@@ -3,18 +3,19 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 //
 
-using HoloToolkit.Unity;
-
-/// <summary>
-/// Implements functionality for building HoloLens applications
-/// </summary>
-public static class HoloToolkitCommands
+namespace HoloToolkit.Unity
 {
     /// <summary>
-    /// Do a build configured for the HoloLens, returns the error from BuildPipeline.BuildPlayer
+    /// Implements functionality for building HoloLens applications
     /// </summary>
-    public static bool BuildSLN()
+    public static class HoloToolkitCommands
     {
-        return BuildDeployTools.BuildSLN(BuildDeployPrefs.BuildDirectory, false);
+        /// <summary>
+        /// Do a build configured for the HoloLens, returns the error from BuildPipeline.BuildPlayer
+        /// </summary>
+        public static bool BuildSLN()
+        {
+            return BuildDeployTools.BuildSLN(BuildDeployPrefs.BuildDirectory, false);
+        }
     }
 }

--- a/Assets/HoloToolkit/Build/Editor/UwpProjectPostProcess.cs.meta
+++ b/Assets/HoloToolkit/Build/Editor/UwpProjectPostProcess.cs.meta
@@ -10,3 +10,4 @@ MonoImporter:
   userData: 
   assetBundleName: 
   assetBundleVariant: 
+  

--- a/Assets/HoloToolkit/Utilities/Scripts/Editor/ExternalProcess.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Editor/ExternalProcess.cs
@@ -31,10 +31,10 @@ namespace HoloToolkit.Unity
 
         private IntPtr mHandle;
 
-        /*
-        * First some static utility functions, used by some other code as well.
-        * They are related to "external processes" so they appear here.
-        */
+        /// <summary>
+        /// First some static utility functions, used by some other code as well.
+        /// They are related to "external processes" so they appear here.
+        /// </summary>
         private static string sAppDataPath;
 
         public static void Launch(string appName)
@@ -136,9 +136,11 @@ namespace HoloToolkit.Unity
             return relativePath.OriginalString;
         }
 
-        /*
-        * The actual ExternalProcess class.
-        */
+        /// <summary>
+        /// The actual ExternalProcess class.
+        /// </summary>
+        /// <param name="appName"></param>
+        /// <returns></returns>
         public static ExternalProcess CreateExternalProcess(string appName)
         {
             return CreateExternalProcess(appName, null);

--- a/Assets/HoloToolkit/Utilities/Scripts/Editor/USBDeviceInfo.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Editor/USBDeviceInfo.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using UnityEngine;
+
+namespace HoloToolkit.Unity
+{
+    [Serializable]
+    public class USBDeviceInfo
+    {
+        public USBDeviceInfo(int vendorId, string udid, int productId, string name, int revision)
+        {
+            VendorId = vendorId;
+            Udid = udid;
+            ProductId = productId;
+            Name = name;
+            Revision = revision;
+        }
+
+        [SerializeField]
+        public int VendorId { get; private set; }
+
+        [SerializeField]
+        public string Udid { get; private set; }
+
+        [SerializeField]
+        public int ProductId { get; private set; }
+
+        [SerializeField]
+        public string Name { get; private set; }
+
+        [SerializeField]
+        public int Revision { get; private set; }
+    }
+}

--- a/Assets/HoloToolkit/Utilities/Scripts/Editor/USBDeviceInfo.cs.meta
+++ b/Assets/HoloToolkit/Utilities/Scripts/Editor/USBDeviceInfo.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c5e55757366a403cb092abaff6b6a15d
+timeCreated: 1497305870

--- a/Assets/HoloToolkit/Utilities/Scripts/Editor/USBDeviceListener.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Editor/USBDeviceListener.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEditor.Hardware;
+using UnityEngine;
+
+namespace HoloToolkit.Unity
+{
+    [InitializeOnLoad]
+    public class USBDeviceListener
+    {
+        [SerializeField]
+        public static USBDeviceInfo[] USBDevices;
+
+        public delegate void OnUsbDevicesChanged(UsbDevice[] usbDevices);
+
+        public static event OnUsbDevicesChanged UsbDevicesChanged;
+
+        private static List<USBDeviceInfo> usbDevicesList = new List<USBDeviceInfo>(0);
+
+        static USBDeviceListener()
+        {
+            Usb.DevicesChanged += NotifyUsbDevicesChanged;
+        }
+
+        private static void NotifyUsbDevicesChanged(UsbDevice[] devices)
+        {
+            if (UsbDevicesChanged != null)
+            {
+                UsbDevicesChanged.Invoke(devices);
+            }
+
+            usbDevicesList.Clear();
+
+            foreach (UsbDevice device in devices)
+            {
+                usbDevicesList.Add(new USBDeviceInfo(device.vendorId, device.udid, device.productId, device.name, device.revision));
+            }
+
+            USBDevices = usbDevicesList.ToArray();
+        }
+    }
+}

--- a/Assets/HoloToolkit/Utilities/Scripts/Editor/USBDeviceListener.cs.meta
+++ b/Assets/HoloToolkit/Utilities/Scripts/Editor/USBDeviceListener.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fc26d07c1945497f97ae60db9eb11a91
+timeCreated: 1497297319


### PR DESCRIPTION
Port of https://github.com/Microsoft/HoloToolkit-Unity/pull/714.
I can't test this bc I don't have the special build of unity needed, so if anyone can, that'd be great.

- Fixes https://github.com/Microsoft/HoloToolkit-Unity/issues/688 Building only for D3D. Now uses build settings.
- Fixes https://github.com/Microsoft/HoloToolkit-Unity/issues/685 Added Support for MSBuild 15+ while keeping backwards compatibility.
- Fixes https://github.com/Microsoft/HoloToolkit-Unity/issues/615
- Fixes https://github.com/Microsoft/HoloToolkit-Unity/issues/612
- Fixes https://github.com/Microsoft/HoloToolkit-Unity/issues/601 Fixed Build Failure due to App Name with Space.
- Fixes https://github.com/Microsoft/HoloToolkit-Unity/issues/583 Added UWP SDK pop up so users can choose sdk version in build window.
- Fixes https://github.com/Microsoft/HoloToolkit-Unity/issues/255 Fixed issue with bad builds returning error code 0.
- Fixes https://github.com/Microsoft/HoloToolkit-Unity/issues/189 Added ability to select a certificate and input password (Users can only create new certs from the Player Settings Window).
- Added workaround to unity bug where `project.json` and `project.lock.json` are not copied correctly to the target build path. (See [UwpBuildTest](https://github.com/StephenHodgson/UwpBuildTest))
- Added Scrollbar for APPX package list.
- Added checks for SLN existing before attempting to make APPX.
- Disabled buttons if HoloLens is not detected via usb.
- Merged changes from [RS2_MixedReality](https://github.com/Microsoft/HoloToolkit-Unity/pull/572/files#diff-915d8ae44ef16ebac775ab81e0cdf317) branch that specifically addressed changes to Build Window.
- Changed Build Configuration from a string field to an enum popup.
- Added a button to open the appx packages location.

![image](https://user-images.githubusercontent.com/13334553/27014129-33c39e86-4ec0-11e7-894b-5ef6be511130.png)
