### PR TITLE
[InputManager] Fix for double event handling with global listener.

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/InputManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputManager.cs
@@ -94,7 +94,14 @@ namespace HoloToolkit.Unity.InputModule
         /// <param name="listener">Listener to add.</param>
         public void AddGlobalListener(GameObject listener)
         {
-            globalListeners.Add(listener);
+            if (!globalListeners.Contains(listener))
+            {
+                globalListeners.Add(listener);
+            }
+            else
+            {
+                Debug.LogWarning("Listener has already been added.");
+            }
         }
 
         /// <summary>

--- a/Assets/HoloToolkit/Input/Scripts/InputManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputManager.cs
@@ -100,7 +100,7 @@ namespace HoloToolkit.Unity.InputModule
             }
             else
             {
-                Debug.LogWarning("Listener has already been added.");
+                Debug.LogWarningFormat("[{0}] This listener has already been added.", listener.name);
             }
         }
 

--- a/Assets/HoloToolkit/Input/Scripts/InputManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputManager.cs
@@ -235,9 +235,9 @@ namespace HoloToolkit.Unity.InputModule
             }
 
             // Use focused object when OverrideFocusedObject is null.
-            GameObject focusedObject = (OverrideFocusedObject == null) ? GazeManager.Instance.HitObject : OverrideFocusedObject;
+            GameObject focusedObject = OverrideFocusedObject == null ? GazeManager.Instance.HitObject : OverrideFocusedObject;
 
-            // Handle modal input if one exists
+            // Handle modal input if one exists.
             if (modalInputStack.Count > 0)
             {
                 GameObject modalInput = modalInputStack.Peek();
@@ -263,8 +263,7 @@ namespace HoloToolkit.Unity.InputModule
             // If event was not handled by modal, pass it on to the current focused object.
             if (focusedObject != null)
             {
-                bool eventHandled = ExecuteEvents.ExecuteHierarchy(focusedObject, eventData, eventHandler);
-                if (eventHandled)
+                if (ExecuteEvents.ExecuteHierarchy(focusedObject, eventData, eventHandler))
                 {
                     return;
                 }
@@ -274,8 +273,11 @@ namespace HoloToolkit.Unity.InputModule
             if (fallbackInputStack.Count > 0)
             {
                 GameObject fallbackInput = fallbackInputStack.Peek();
-                ExecuteEvents.ExecuteHierarchy(fallbackInput, eventData, eventHandler);
-                return;
+
+                if (ExecuteEvents.ExecuteHierarchy(fallbackInput, eventData, eventHandler))
+                {
+                    return;
+                }
             }
 
             // Finally, if the event is not handled by the fallback handler, pass it to the global listeners.

--- a/Assets/HoloToolkit/Input/Scripts/InputManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputManager.cs
@@ -63,7 +63,7 @@ namespace HoloToolkit.Unity.InputModule
 
         /// <summary>
         /// Push a game object into the modal input stack. Any input handlers
-        /// on the game object is given priority to input events before any focused objects.
+        /// on the game object are given priority to input events before any focused objects.
         /// </summary>
         /// <param name="inputHandler">The input handler to push</param>
         public void PushModalInputHandler(GameObject inputHandler)
@@ -243,8 +243,8 @@ namespace HoloToolkit.Unity.InputModule
             for (int i = 0; i < globalListeners.Count; i++)
             {
                 // Only execute the global event if it's not already being handled.
-                if (globalListeners[i] != focusedObject ||
-                    globalListeners[i] != modalInput ||
+                if (globalListeners[i] != focusedObject &&
+                    globalListeners[i] != modalInput &&
                     globalListeners[i] != fallbackInput)
                 {
                     // Global listeners should only get events on themselves, as opposed to their hierarchy.

--- a/Assets/HoloToolkit/Input/Scripts/InputManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/InputManager.cs
@@ -237,20 +237,12 @@ namespace HoloToolkit.Unity.InputModule
             // Use focused object when OverrideFocusedObject is null.
             GameObject focusedObject = (OverrideFocusedObject == null) ? GazeManager.Instance.HitObject : OverrideFocusedObject;
 
-            // Send the event to global listeners
-            for (int i = 0; i < globalListeners.Count; i++)
-            {
-                // Global listeners should only get events on themselves, as opposed to their hierarchy
-                ExecuteEvents.Execute(globalListeners[i], eventData, eventHandler);
-            }
-
             // Handle modal input if one exists
             if (modalInputStack.Count > 0)
             {
                 GameObject modalInput = modalInputStack.Peek();
 
-                // If there is a focused object in the hierarchy of the modal handler, start the event
-                // bubble there
+                // If there is a focused object in the hierarchy of the modal handler, start the event bubble there.
                 if (focusedObject != null && modalInput != null && focusedObject.transform.IsChildOf(modalInput.transform))
                 {
                     if (ExecuteEvents.ExecuteHierarchy(focusedObject, eventData, eventHandler))
@@ -258,7 +250,7 @@ namespace HoloToolkit.Unity.InputModule
                         return;
                     }
                 }
-                // Otherwise, just invoke the event on the modal handler itself
+                // Otherwise, just invoke the event on the modal handler itself.
                 else
                 {
                     if (ExecuteEvents.ExecuteHierarchy(modalInput, eventData, eventHandler))
@@ -268,7 +260,7 @@ namespace HoloToolkit.Unity.InputModule
                 }
             }
 
-            // If event was not handled by modal, pass it on to the current focused object
+            // If event was not handled by modal, pass it on to the current focused object.
             if (focusedObject != null)
             {
                 bool eventHandled = ExecuteEvents.ExecuteHierarchy(focusedObject, eventData, eventHandler);
@@ -278,11 +270,19 @@ namespace HoloToolkit.Unity.InputModule
                 }
             }
 
-            // If event was not handled by the focused object, pass it on to any fallback handlers
+            // If event was not handled by the focused object, pass it on to any fallback handlers.
             if (fallbackInputStack.Count > 0)
             {
                 GameObject fallbackInput = fallbackInputStack.Peek();
                 ExecuteEvents.ExecuteHierarchy(fallbackInput, eventData, eventHandler);
+                return;
+            }
+
+            // Finally, if the event is not handled by the fallback handler, pass it to the global listeners.
+            for (int i = 0; i < globalListeners.Count; i++)
+            {
+                // Global listeners should only get events on themselves, as opposed to their hierarchy.
+                ExecuteEvents.Execute(globalListeners[i], eventData, eventHandler);
             }
         }
 


### PR DESCRIPTION
- Fixes https://github.com/Microsoft/HoloToolkit-Unity/issues/756: Only executes global event if not already being handled.
- Added check if listener was already added to the global list.