### PR TITLE
Update Unity Editor to 2017.1.0f3

### DIFF
--- a/Assets/HoloToolkit/Build/Editor/BuildSLNUtilities.cs
+++ b/Assets/HoloToolkit/Build/Editor/BuildSLNUtilities.cs
@@ -102,29 +102,22 @@ namespace HoloToolkit.Unity
 
             EditorUserBuildSettings.SwitchActiveBuildTarget(buildTargetGroup, buildInfo.BuildTarget);
 
-            WSASDK oldWSASDK = EditorUserBuildSettings.wsaSDK;
-            if (buildInfo.WSASdk.HasValue)
-            {
-                EditorUserBuildSettings.wsaSDK = buildInfo.WSASdk.Value;
-            }
+            WSAUWPBuildType? oldWSAUWPBuildType = EditorUserBuildSettings.wsaUWPBuildType;
 
-            WSAUWPBuildType? oldWSAUWPBuildType = null;
-            if (EditorUserBuildSettings.wsaSDK == WSASDK.UWP)
+            if (buildInfo.WSAUWPBuildType.HasValue)
             {
-                oldWSAUWPBuildType = EditorUserBuildSettings.wsaUWPBuildType;
-                if (buildInfo.WSAUWPBuildType.HasValue)
-                {
-                    EditorUserBuildSettings.wsaUWPBuildType = buildInfo.WSAUWPBuildType.Value;
-                }
+                EditorUserBuildSettings.wsaUWPBuildType = buildInfo.WSAUWPBuildType.Value;
             }
 
             var oldWSAGenerateReferenceProjects = EditorUserBuildSettings.wsaGenerateReferenceProjects;
+
             if (buildInfo.WSAGenerateReferenceProjects.HasValue)
             {
                 EditorUserBuildSettings.wsaGenerateReferenceProjects = buildInfo.WSAGenerateReferenceProjects.Value;
             }
 
             var oldColorSpace = PlayerSettings.colorSpace;
+
             if (buildInfo.ColorSpace.HasValue)
             {
                 PlayerSettings.colorSpace = buildInfo.ColorSpace.Value;
@@ -138,10 +131,7 @@ namespace HoloToolkit.Unity
             string buildError = "Error";
             try
             {
-                if (EditorUserBuildSettings.wsaSDK == WSASDK.UWP)
-                {
-                    VerifyWsaUwpSdkIsInstalled(EditorUserBuildSettings.wsaUWPSDK);
-                }
+                VerifyWsaUwpSdkIsInstalled(EditorUserBuildSettings.wsaUWPSDK);
 
                 // For the WSA player, Unity builds into a target directory.
                 // For other players, the OutputPath parameter indicates the
@@ -179,8 +169,6 @@ namespace HoloToolkit.Unity
                 {
                     EditorUserBuildSettings.wsaUWPBuildType = oldWSAUWPBuildType.Value;
                 }
-
-                EditorUserBuildSettings.wsaSDK = oldWSASDK;
 
                 EditorUserBuildSettings.wsaGenerateReferenceProjects = oldWSAGenerateReferenceProjects;
 
@@ -371,7 +359,9 @@ namespace HoloToolkit.Unity
 
                     case XmlNodeType.EndElement:
                         if (string.Equals(reader.Name, "SceneList", StringComparison.InvariantCultureIgnoreCase))
+                        {
                             return result;
+                        }
                         break;
                 }
             }

--- a/Assets/HoloToolkit/Utilities/Scripts/Editor/ProjectSettingsWindow.cs
+++ b/Assets/HoloToolkit/Utilities/Scripts/Editor/ProjectSettingsWindow.cs
@@ -205,7 +205,6 @@ namespace HoloToolkit.Unity
             if (Values[ProjectSetting.BuildWsaUwp])
             {
                 EditorUserBuildSettings.SwitchActiveBuildTarget(BuildTargetGroup.WSA, BuildTarget.WSAPlayer);
-                EditorUserBuildSettings.wsaSDK = WSASDK.UWP;
             }
             if (Values[ProjectSetting.WsaUwpBuildToD3D])
             {

--- a/Assets/HoloToolkit/Utilities/Shaders/FastConfigurable/Editor/CustomMaterialEditor.cs
+++ b/Assets/HoloToolkit/Utilities/Shaders/FastConfigurable/Editor/CustomMaterialEditor.cs
@@ -29,9 +29,11 @@ namespace HoloToolkit.Unity
             controlRect.x += EditorGUIUtility.labelWidth;
             controlRect.width = EditorGUIUtility.fieldWidth;
 
-            GUIContent toggleTooltip = new GUIContent();
-            toggleTooltip.text = string.Empty;
-            toggleTooltip.tooltip = "Enable/Disable color";
+            var toggleTooltip = new GUIContent
+            {
+                text = string.Empty,
+                tooltip = "Enable/Disable color"
+            };
 
             //label indent of -1 is the secret sauce to make it aligned with right aligned toggles that come after labels
             //ShaderProperty handles begin and end animation checks
@@ -45,9 +47,11 @@ namespace HoloToolkit.Unity
                 //size it to take up the remainder of the space
                 controlRect.width = lineRect.width - controlRect.x;
 
-                GUIContent tooltipOnly = new GUIContent();
-                tooltipOnly.text = string.Empty;
-                tooltipOnly.tooltip = label.tooltip;
+                var tooltipOnly = new GUIContent
+                {
+                    text = string.Empty,
+                    tooltip = label.tooltip
+                };
 
                 EditorGUI.showMixedValue = colorProp.hasMixedValue;
                 EditorGUI.BeginChangeCheck();
@@ -91,32 +95,33 @@ namespace HoloToolkit.Unity
             MaterialProperty scaleOffsetProp
         )
         {
-            var rect = CustomMaterialEditor.TextureWithToggleableColorSingleLine(matEditor, label, textureProp, colorToggleProp, colorProp);
+            var rect = TextureWithToggleableColorSingleLine(matEditor, label, textureProp, colorToggleProp, colorProp);
 
-            CustomMaterialEditor.SetScaleOffsetKeywords(matEditor, textureProp, scaleOffsetProp);
+            SetScaleOffsetKeywords(matEditor, textureProp, scaleOffsetProp);
 
             return rect;
         }
 
-        public static void TextureScaleOffsetVector4Property(MaterialEditor matEditor, GUIContent label, MaterialProperty scaleOffsetProp)
+        public static void TextureScaleOffsetVector4Property(MaterialEditor matEditor, MaterialProperty scaleOffsetProp)
         {
-            matEditor.BeginAnimatedCheck(scaleOffsetProp);
+            matEditor.BeginAnimatedCheck(GetControlRectForSingleLine(), scaleOffsetProp);
 
             EditorGUI.showMixedValue = scaleOffsetProp.hasMixedValue;
             EditorGUI.BeginChangeCheck();
 
             Vector4 scaleOffsetVector = scaleOffsetProp.vectorValue;
 
-            Vector2 textureScale = new Vector2(scaleOffsetVector.x, scaleOffsetVector.y);
-            textureScale = EditorGUILayout.Vector2Field(Styles.scale, textureScale, new GUILayoutOption[0]);
+            var textureScale = new Vector2(scaleOffsetVector.x, scaleOffsetVector.y);
+            textureScale = EditorGUILayout.Vector2Field(Styles.scale, textureScale);
 
-            Vector2 textureOffset = new Vector2(scaleOffsetVector.z, scaleOffsetVector.w);
-            textureOffset = EditorGUILayout.Vector2Field(Styles.offset, textureOffset, new GUILayoutOption[0]);
+            var textureOffset = new Vector2(scaleOffsetVector.z, scaleOffsetVector.w);
+            textureOffset = EditorGUILayout.Vector2Field(Styles.offset, textureOffset);
 
             if (EditorGUI.EndChangeCheck())
             {
                 scaleOffsetProp.vectorValue = new Vector4(textureScale.x, textureScale.y, textureOffset.x, textureOffset.y);
             }
+
             EditorGUI.showMixedValue = false;
 
             matEditor.EndAnimatedCheck();
@@ -124,7 +129,7 @@ namespace HoloToolkit.Unity
 
         public static Rect GetControlRectForSingleLine()
         {
-            return EditorGUILayout.GetControlRect(true, 18f, EditorStyles.layerMaskField, new GUILayoutOption[0]);
+            return EditorGUILayout.GetControlRect(true, 18f, EditorStyles.layerMaskField);
         }
 
         private static class Styles

--- a/Assets/HoloToolkit/Utilities/Shaders/FastConfigurable/Editor/FastConfigurableGUI.cs
+++ b/Assets/HoloToolkit/Utilities/Shaders/FastConfigurable/Editor/FastConfigurableGUI.cs
@@ -112,7 +112,8 @@ namespace HoloToolkit.Unity
             {
                 matEditor.ShaderProperty(vertexColorEnabled, Styles.vertexColorEnabled);
 
-                CustomMaterialEditor.TextureWithToggleableColorAutoScaleOffsetSingleLine(matEditor, Styles.main,
+                CustomMaterialEditor.TextureWithToggleableColorAutoScaleOffsetSingleLine(matEditor,
+                                                                                         Styles.main,
                                                                                          mainTexture,
                                                                                          mainColorEnabled, mainColor,
                                                                                          textureScaleAndOffset);
@@ -179,7 +180,7 @@ namespace HoloToolkit.Unity
 
             ShaderGUIUtils.BeginHeader("Global");
             {
-                CustomMaterialEditor.TextureScaleOffsetVector4Property(matEditor, Styles.textureScaleAndOffset, textureScaleAndOffset);
+                CustomMaterialEditor.TextureScaleOffsetVector4Property(matEditor, textureScaleAndOffset);
             }
             ShaderGUIUtils.EndHeader();
             ShaderGUIUtils.HeaderSeparator();

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -3,7 +3,7 @@
 --- !u!129 &1
 PlayerSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 11
+  serializedVersion: 12
   productGUID: 4dcb8c58cabfde44da6ffb0c21242af7
   AndroidProfiler: 0
   defaultScreenOrientation: 4
@@ -70,6 +70,7 @@ PlayerSettings:
   captureSingleScreen: 0
   muteOtherAudioSources: 0
   Prepare IOS For Recording: 0
+  Force IOS Speakers When Recording: 0
   submitAnalytics: 1
   usePlayerLog: 1
   bakeCollisionMeshes: 0
@@ -101,6 +102,7 @@ PlayerSettings:
   xboxOneResolution: 0
   xboxOneMonoLoggingLevel: 0
   xboxOneLoggingLevel: 1
+  xboxOneDisableEsram: 0
   videoMemoryForVertexBuffers: 0
   psp2PowerMode: 0
   psp2AcquireBGM: 1
@@ -136,6 +138,8 @@ PlayerSettings:
       depthFormat: 1
   protectGraphicsMemory: 0
   useHDRDisplay: 0
+  targetPixelDensity: 0
+  resolutionScalingMode: 0
   applicationIdentifier:
     Android: com.Company.ProductName
     Standalone: unity.DefaultCompany.HoloToolkit-Unity
@@ -468,7 +472,6 @@ PlayerSettings:
   ps4GarlicHeapSize: 2048
   ps4ProGarlicHeapSize: 2560
   ps4Passcode: frAQBc8Wsa1xVPfvJcrgRYwTiizs2trQ
-  ps4UseDebugIl2cppLibs: 0
   ps4pnSessions: 1
   ps4pnPresence: 1
   ps4pnFriends: 1
@@ -543,7 +546,7 @@ PlayerSettings:
   psp2UseLibLocation: 0
   psp2InfoBarOnStartup: 0
   psp2InfoBarColor: 0
-  psp2UseDebugIl2cppLibs: 0
+  psp2ScriptOptimizationLevel: 0
   psmSplashimage: {fileID: 0}
   splashScreenBackgroundSourceLandscape: {fileID: 0}
   splashScreenBackgroundSourcePortrait: {fileID: 0}
@@ -569,6 +572,7 @@ PlayerSettings:
     WebPlayer: 0
   incrementalIl2cppBuild: {}
   additionalIl2CppArgs: 
+  scriptingRuntimeVersion: 0
   apiCompatibilityLevelPerPlatform: {}
   m_RenderingPath: 1
   m_MobileRenderingPath: 1
@@ -692,4 +696,5 @@ PlayerSettings:
   projectName: 
   organizationId: 
   cloudEnabled: 0
-  enableNewInputSystem: 0
+  enableNativePlatformBackendsForNewInputSystem: 0
+  disableOldInputManagerSupport: 0

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 5.6.2f1
+m_EditorVersion: 2017.1.0f3

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This is effectively part of the existing HoloToolkit, but this is the repository that will contain all Unity specific components.
 The HoloToolkit is a collection of scripts and components intended to accelerate development of holographic applications targeting Windows Holographic.
 
-**Required Unity Editor Version: 5.6.2f1**
+**Required Unity Editor Version: 2017.1.0f3**
 
 HoloToolkit contains the following feature areas:
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 This is effectively part of the existing HoloToolkit, but this is the repository that will contain all Unity specific components.
 The HoloToolkit is a collection of scripts and components intended to accelerate development of holographic applications targeting Windows Holographic.
 
-**Required Unity Editor Version: [2017.1.0f3](https://unity3d.com/unity/whats-new/unity-2017.1.0)**
+## Required Software
+- Unity Editor Version: [2017.1.0f3](https://unity3d.com/unity/whats-new/unity-2017.1.0)
+- Visual Studio 2017
 
-HoloToolkit contains the following feature areas:
+## HoloToolkit contains the following feature areas:
 
 1. [Input](Assets/HoloToolkit/Input/README.md)
 2. [Sharing](Assets/HoloToolkit/Sharing/README.md)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This is effectively part of the existing HoloToolkit, but this is the repository that will contain all Unity specific components.
 The HoloToolkit is a collection of scripts and components intended to accelerate development of holographic applications targeting Windows Holographic.
 
-**Required Unity Editor Version: 2017.1.0f3**
+**Required Unity Editor Version: [2017.1.0f3](https://unity3d.com/unity/whats-new/unity-2017.1.0)**
 
 HoloToolkit contains the following feature areas:
 


### PR DESCRIPTION
Resolves https://github.com/Microsoft/HoloToolkit-Unity/issues/767
- Removed references to `EditorUserBuildSettings.wsaSDK`.  It is obsolete and has no effect and will be removed in a subsequent Unity release.
- Fixed `BeginAnimatedCheck` overload.
- Fixed `TextureScaleOffsetVector4Property` overload.
- Updated `ProjectSettings`.
- Updated Project version.