### PR TITLE
Updated GazeManager uGUI raycast calculations & GazeTransform initialization 

### DIFF
--- a/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
@@ -231,9 +231,6 @@ namespace HoloToolkit.Unity.InputModule
             // If we have a raycast result, check if we need to overwrite the 3D raycast info
             if (uiRaycastResult.gameObject != null)
             {
-                // Add the near clip distance since this is where the raycast is from
-                float uiRaycastDistance = uiRaycastResult.distance + Camera.main.nearClipPlane;
-
                 bool superseded3DObject = false;
                 if (IsGazingAtObject)
                 {
@@ -250,7 +247,7 @@ namespace HoloToolkit.Unity.InputModule
                         }
                         else if (threeDLayerIndex == uiLayerIndex)
                         {
-                            if (hitInfo.distance > uiRaycastDistance)
+                            if (hitInfo.distance > uiRaycastResult.distance)
                             {
                                 superseded3DObject = true;
                             }
@@ -258,7 +255,7 @@ namespace HoloToolkit.Unity.InputModule
                     }
                     else
                     {
-                        if (hitInfo.distance > uiRaycastDistance)
+                        if (hitInfo.distance > uiRaycastResult.distance)
                         {
                             superseded3DObject = true;
                         }
@@ -269,10 +266,10 @@ namespace HoloToolkit.Unity.InputModule
                 if (!IsGazingAtObject || superseded3DObject)
                 {
                     IsGazingAtObject = true;
-                    Vector3 worldPos = Camera.main.ScreenToWorldPoint(new Vector3(uiRaycastResult.screenPosition.x, uiRaycastResult.screenPosition.y, uiRaycastDistance));
-                    hitInfo = new RaycastHit()
+                    Vector3 worldPos = Camera.main.ScreenToWorldPoint(new Vector3(uiRaycastResult.screenPosition.x, uiRaycastResult.screenPosition.y, uiRaycastResult.distance));
+                    hitInfo = new RaycastHit
                     {
-                        distance = uiRaycastDistance,
+                        distance = uiRaycastResult.distance,
                         normal = -Camera.main.transform.forward,
                         point = worldPos
                     };
@@ -313,9 +310,9 @@ namespace HoloToolkit.Unity.InputModule
                 }
             }
 
-             return minHit ?? new RaycastResult();
+            return minHit ?? new RaycastResult();
         }
-        
+
         /// <summary>
         /// Look through the layerMaskList and find the index in that list for which the supplied layer is part of
         /// </summary>

--- a/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
@@ -225,7 +225,7 @@ namespace HoloToolkit.Unity.InputModule
             // Graphics raycast
             raycastResultList.Clear();
             EventSystem.current.RaycastAll(UnityUIPointerEvent, raycastResultList);
-            RaycastResult uiRaycastResult = FindClosestRaycastHitInLayermasks(raycastResultList, RaycastLayerMasks);
+            RaycastResult uiRaycastResult = FindClosestRaycastHitInLayerMasks(raycastResultList, RaycastLayerMasks);
             UnityUIPointerEvent.pointerCurrentRaycast = uiRaycastResult;
 
             // If we have a raycast result, check if we need to overwrite the 3D raycast info
@@ -289,7 +289,7 @@ namespace HoloToolkit.Unity.InputModule
         /// <param name="candidates">List of RaycastResults from a Unity UI raycast</param>
         /// <param name="layerMaskList">List of layers to support</param>
         /// <returns>RaycastResult if hit, or an empty RaycastResult if nothing was hit</returns>
-        private RaycastResult FindClosestRaycastHitInLayermasks(List<RaycastResult> candidates, LayerMask[] layerMaskList)
+        private RaycastResult FindClosestRaycastHitInLayerMasks(List<RaycastResult> candidates, LayerMask[] layerMaskList)
         {
             int combinedLayerMask = 0;
             for (int i = 0; i < layerMaskList.Length; i++)

--- a/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
+++ b/Assets/HoloToolkit/Input/Scripts/Gaze/GazeManager.cs
@@ -93,7 +93,7 @@ namespace HoloToolkit.Unity.InputModule
         public PointerEventData UnityUIPointerEvent { get; private set; }
 
         /// <summary>
-        /// Cached results of racast results.
+        /// Cached results of raycast results.
         /// </summary>
         private List<RaycastResult> raycastResultList = new List<RaycastResult>();
 
@@ -106,26 +106,13 @@ namespace HoloToolkit.Unity.InputModule
             {
                 RaycastLayerMasks = new LayerMask[] { Physics.DefaultRaycastLayers };
             }
-        }
 
-        private void Start()
-        {
-            if (GazeTransform == null)
-            {
-                if (Camera.main != null)
-                {
-                    GazeTransform = Camera.main.transform;
-                }
-                else
-                {
-                    Debug.LogError("Gaze Manager was not given a GazeTransform and no main camera exists to default to.");
-                }
-            }
+            FindGazeTransform();
         }
 
         private void Update()
         {
-            if (GazeTransform == null)
+            if (!FindGazeTransform())
             {
                 return;
             }
@@ -147,6 +134,20 @@ namespace HoloToolkit.Unity.InputModule
             {
                 FocusedObjectChanged(previousFocusObject, HitObject);
             }
+        }
+
+        private bool FindGazeTransform()
+        {
+            if (GazeTransform != null) { return true; }
+
+            if (Camera.main != null)
+            {
+                GazeTransform = Camera.main.transform;
+                return true;
+            }
+
+            Debug.LogError("Gaze Manager was not given a GazeTransform and no main camera exists to default to.");
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
- Fixed https://github.com/Microsoft/HoloToolkit-Unity/issues/804 where uGUI raycasting was compensating for Unity Bug.  Unity now correctly calculates raycast value from the near clip plane.
- Fixed https://github.com/Microsoft/HoloToolkit-Unity/issues/778 by checking the `GazeTransform` in update and moving the initialization from `Start` to `Awake`.