### PR TITLE
support for backspace deleting selected text

### DIFF
--- a/Assets/HoloToolkit/UI/Scripts/Keyboard.cs
+++ b/Assets/HoloToolkit/UI/Scripts/Keyboard.cs
@@ -630,13 +630,34 @@ namespace HoloToolkit.UI.Keyboard
         /// </summary>
         public void Backspace()
         {
-            m_CaretPosition = m_InputField.caretPosition;
-
-            if (m_CaretPosition > 0)
+            // check if text is selected
+            if (m_InputField.selectionFocusPosition != m_InputField.caretPosition || m_InputField.selectionAnchorPosition != m_InputField.caretPosition)
             {
-                --m_CaretPosition;
-                m_InputField.text = m_InputField.text.Remove(m_CaretPosition, 1);
-                UpdateCaratPosition(m_CaretPosition);
+                if (m_InputField.selectionAnchorPosition > m_InputField.selectionFocusPosition) // right to left
+                {
+                    m_InputField.text = m_InputField.text.Substring(0, m_InputField.selectionFocusPosition) + m_InputField.text.Substring(m_InputField.selectionAnchorPosition);
+                    m_InputField.caretPosition = m_InputField.selectionFocusPosition;
+                }
+                else // left to right
+                {
+                    m_InputField.text = m_InputField.text.Substring(0, m_InputField.selectionAnchorPosition) + m_InputField.text.Substring(m_InputField.selectionFocusPosition);
+                    m_InputField.caretPosition = m_InputField.selectionAnchorPosition;
+                }
+
+                m_CaretPosition = m_InputField.caretPosition;
+                m_InputField.selectionAnchorPosition = m_CaretPosition;
+                m_InputField.selectionFocusPosition = m_CaretPosition;
+            }
+            else
+            {
+                m_CaretPosition = m_InputField.caretPosition;
+
+                if (m_CaretPosition > 0)
+                {
+                    --m_CaretPosition;
+                    m_InputField.text = m_InputField.text.Remove(m_CaretPosition, 1);
+                    UpdateCaratPosition(m_CaretPosition);
+                }
             }
         }
 


### PR DESCRIPTION
The new HoloToolkit supports selecting ranges of text (a standard feature of an InputField) and will autoselect all text when opening a keyboard with text already set, but currently will not delete selected text with the backspace key. Fix will delete the selected text and set the cursor to that position.